### PR TITLE
New default config for translation metadata, adds beta repo w/ working atlases

### DIFF
--- a/src/core/hachimi.rs
+++ b/src/core/hachimi.rs
@@ -318,7 +318,7 @@ impl Config {
     fn default_ui_scale() -> f32 { 1.0 }
     fn default_story_choice_auto_select_delay() -> f32 { 0.75 }
     fn default_story_tcps_multiplier() -> f32 { 1.0 }
-    fn default_meta_index_url() -> String { "https://files.leadrdrk.com/hachimi/meta/index.json".to_owned() }
+    fn default_meta_index_url() -> String { "https://github.com/Rekoiru/meta/raw/refs/heads/main/meta.json".to_owned() }
     fn default_ui_animation_scale() -> f32 { 1.0 }
 }
 


### PR DESCRIPTION
In an effort to make Hachimi-Edge installation easier while Lead is away, I worked with Rekoiru to automate the creation of new English translation index.json files directly from his translation repo. As the timeline is currently uncertain with upstream Hachimi, Reko's repo is the only source of translated sprites without major graphical glitches.
This PR updates the default Hachimi-Edge config to point to the new meta file, offering Reko's beta translations as the default option.

Development pushes to [his repo](https://github.com/Rekoiru/tl-en) will trigger a webhook payload sent to a separate meta repo, where a GitHub Action checks out the latest changes & generates a new index.json with the latest TLs. The meta repo is located here: https://github.com/Rekoiru/meta

I built hachimi.dll with the new metadata URL as the default and first setup as well as translation updates are working as expected. Video in action: https://files.teiostep.com/hachimi-test.mp4

Hopefully this slows down the amount of "omg help me my graphics are broken" messages in the Discord lmao