### PR TITLE
Update Windows releases to use version-agnostic installer

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -56,13 +56,17 @@ jobs:
           move build\x86_64-pc-windows-msvc\release\cellar.dll build
           cd ..
 
+      - name: Check out FunnyHoney
+        run: git clone --depth 1 https://codeberg.org/LeadRDRK/FunnyHoney.git
+
       - name: Build Installer
         run: |
-          git clone --depth 1 https://github.com/Hachimi-Hachimi/Installer
+          git clone --depth 1 https://github.com/teiosteppa/Installer
           copy build\hachimi.dll Installer
           move Cellar\build\cellar.dll Installer
+          move FunnyHoney\FunnyHoney.exe Installer
           cd Installer
-          cargo build --target x86_64-pc-windows-msvc --target-dir build --release --features compress_dll
+          cargo build --target x86_64-pc-windows-msvc --target-dir build --release --features compress_bin
           cd ..
           move Installer\build\x86_64-pc-windows-msvc\release\hachimi_installer.exe build
 


### PR DESCRIPTION
My fork of Hachimi installer for both Steam & DMM ver is finally release ready, creating this PR to get it into your build.
Biggest difference UX-wise is that the old target dropdown picker is used to select the game edition now, since Steam will always use the direct `cri_mana_vpx` target and DMM will always use the DotLocal `UnityPlayer` target. The picker is disabled & defaults to the installed edition if only one game edition is installed. Using Lead's old bin patch for direct method, for now.
Build now also checks out Lead's binary & slipstreams it (compression optional) at install time. If Steam target is selected, it'll use the `bsdiff-rs` crate to generate a patch & apply it to the game executable.

video if it helps: [https://files.teiostep.com/ShareX/2025/10/hImNcoyxMw.mp4](https://files.teiostep.com/ShareX/2025/10/hImNcoyxMw.mp4) dont mind my dmm client needing to be restarted it does it to me all the time lmfao