### PR TITLE
Use GitLab mirror for default meta

### DIFF
--- a/src/core/hachimi.rs
+++ b/src/core/hachimi.rs
@@ -318,7 +318,7 @@ impl Config {
     fn default_ui_scale() -> f32 { 1.0 }
     fn default_story_choice_auto_select_delay() -> f32 { 1.2 }
     fn default_story_tcps_multiplier() -> f32 { 3.0 }
-    fn default_meta_index_url() -> String { "https://raw.githubusercontent.com/UmaTL/hachimi-meta/main/meta.json".to_owned() }
+    fn default_meta_index_url() -> String { "https://gitlab.com/umatl/hachimi-meta/-/raw/main/meta.json".to_owned() }
     fn default_ui_animation_scale() -> f32 { 1.0 }
 }
 


### PR DESCRIPTION
Per request by Chinese users.
Mirror auto-updates through actions.