### PR TITLE
Fix incomplete translation in live theater concerts

### DIFF
--- a/src/il2cpp/hook/umamusume/LyricsController.rs
+++ b/src/il2cpp/hook/umamusume/LyricsController.rs
@@ -49,7 +49,7 @@ extern "C" fn LoadLyrics(this: *mut Il2CppObject, id: i32, path: *mut Il2CppStri
     };
     // dont let pbork interactive know about this
     let secs_dict: FnvHashMap<i32, String> = dict.into_iter()
-        .map(|(time, lyrics)| unsafe { (std::mem::transmute(time as f32 / 1000.0), lyrics) })
+        .map(|(time, lyrics)| (f32::to_bits(time as f32 / 1000.0).cast_signed(), lyrics) )
         .collect();
 
     let lyrics_data_dict = get__lyricsDataDic(this);
@@ -57,8 +57,8 @@ extern "C" fn LoadLyrics(this: *mut Il2CppObject, id: i32, path: *mut Il2CppStri
         return true;
     };
     for lyrics_data in unsafe { lyrics_data_array.as_slice().iter_mut() } {
-        // transmute to an i32 so we can do an exact match lookup in the map
-        let time: i32 = unsafe { std::mem::transmute(lyrics_data.time) };
+        // cast as an i32 so we can do an exact match lookup in the map
+        let time: i32 = f32::to_bits(lyrics_data.time).cast_signed();
         if let Some(text) = secs_dict.get(&time) {
             lyrics_data.lyrics = text.to_il2cpp_string();
         }


### PR DESCRIPTION
Fixes Hachimi-Hachimi/Hachimi#68

Members of the `LyricsData` struct changed [some months ago](https://discord.com/channels/1248085334861025350/1248143380437930085/1400924712774664384)
This PR updates the struct in line with members from the latest Il2Cpp metadata, which fixes the incomplete string replacement

also refactored out some transmutes as they're no longer needed in modern versions of Rust