### PR TITLE
Filter repo selection by region

### DIFF
--- a/assets/locales/en.yml
+++ b/assets/locales/en.yml
@@ -79,11 +79,13 @@ first_time_setup:
     you accept that you will be using it at your own risk.
   translation_repo_heading: "Translation repo"
   select_translation_repo: "Select a translation repo:"
+  no_compatible_repo: "No translation repos are compatible with this game version."
+  skip_translation: "Skip translations."
   complete_heading: "All done!"
   complete_content: >-
-    The translation repo has been set. Once you click on Done, the configuration will
-    be saved and an update check will be performed, which will prompt you to download the
-    new translation data.
+    Click on Done to save the configuration.
+    If you chose a translation repo, an update check will be performed,
+    which will prompt you to download the new translation data.
 
 about:
   title: "About"

--- a/src/core/game.rs
+++ b/src/core/game.rs
@@ -1,4 +1,5 @@
 use std::{fmt::Display, path::PathBuf};
+use serde::{Deserialize};
 
 use crate::game_impl;
 
@@ -11,7 +12,7 @@ pub struct Game {
     pub is_steam_release: bool
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Deserialize)]
 pub enum Region {
     Unknown,
     Japan,
@@ -31,6 +32,12 @@ impl Display for Region {
             Region::China => "China",
             Region::Global => "Global"
         })
+    }
+}
+
+impl Default for Region {
+    fn default() -> Self {
+        Region::Japan
     }
 }
 

--- a/src/core/gui.rs
+++ b/src/core/gui.rs
@@ -1190,7 +1190,7 @@ struct FirstTimeSetupWindow {
     id: egui::Id,
     index_request: Arc<AsyncRequest<Vec<RepoInfo>>>,
     current_page: usize,
-    current_tl_repo: usize
+    current_tl_repo: Option<String>
 }
 
 impl FirstTimeSetupWindow {
@@ -1199,7 +1199,7 @@ impl FirstTimeSetupWindow {
             id: random_id(),
             index_request: Arc::new(tl_repo::new_meta_index_request()),
             current_page: 0,
-            current_tl_repo: 0
+            current_tl_repo: None
         }
     }
 }
@@ -1240,23 +1240,31 @@ impl Window for FirstTimeSetupWindow {
                         ui.label(t!("first_time_setup.select_translation_repo"));
                         ui.add_space(4.0);
 
-                        let mut selected = false;
+                        let mut is_index_loaded = false;
                         async_request_ui_content(ui, self.index_request.clone(), |ui, repo_list| {
-                            selected = repo_list.get(self.current_tl_repo).is_some();
+                            is_index_loaded = true;
+                            let filtered_repos: Vec<_> = repo_list.iter()
+                                .filter(|repo| repo.region == Hachimi::instance().game.region)
+                                .collect();
                             egui::ScrollArea::vertical().show(ui, |ui| {
                                 egui::Frame::none()
                                 .inner_margin(egui::Margin::symmetric(8.0, 0.0))
                                 .show(ui, |ui| {
-                                    for (i, repo) in repo_list.iter().enumerate() {
-                                        ui.radio_value(&mut self.current_tl_repo, i, &repo.name);
+                                    if filtered_repos.is_empty() {
+                                        ui.label(t!("first_time_setup.no_compatible_repo"));
+                                        return;
+                                    }
+                                    for repo in filtered_repos {
+                                        ui.radio_value(&mut self.current_tl_repo, Some(repo.index.clone()), &repo.name);
                                         if let Some(short_desc) = &repo.short_desc {
                                             ui.label(egui::RichText::new(short_desc).small());
                                         }
                                     }
+                                    ui.radio_value(&mut self.current_tl_repo, None, t!("first_time_setup.skip_translation"));
                                 });
                             });
                         });
-                        selected
+                        is_index_loaded
                     }
                     2 => {
                         ui.heading(t!("first_time_setup.complete_heading"));
@@ -1276,19 +1284,7 @@ impl Window for FirstTimeSetupWindow {
             config.skip_first_time_setup = true;
 
             if !page_open {
-                let Some(res) = &**self.index_request.result.load() else {
-                    return open_res;
-                };
-
-                let Ok(repo_list) = res else {
-                    return open_res;
-                };
-
-                let Some(repo) = repo_list.get(self.current_tl_repo) else {
-                    return open_res;
-                };
-
-                config.translation_repo_index = Some(repo.index.clone());
+                config.translation_repo_index = self.current_tl_repo.clone();
             }
 
             save_and_reload_config(config);

--- a/src/core/tl_repo.rs
+++ b/src/core/tl_repo.rs
@@ -7,13 +7,17 @@ use serde::{Deserialize, Serialize};
 use size::Size;
 use threadpool::ThreadPool;
 
+use crate::core::game::Region;
+
 use super::{gui::SimpleYesNoDialog, hachimi::LocalizedData, http::{self, AsyncRequest}, utils, Error, Gui, Hachimi};
 
 #[derive(Deserialize)]
 pub struct RepoInfo {
     pub name: String,
     pub index: String,
-    pub short_desc: Option<String>
+    pub short_desc: Option<String>,
+    #[serde(default)]
+    pub region: Region
 }
 
 pub fn new_meta_index_request() -> AsyncRequest<Vec<RepoInfo>> {


### PR DESCRIPTION
Adds a new optional `region` key to `meta.json` (default: `Japan`). This corresponds to the target modded game's region, NOT THE LANGUAGE of the translation repo.

The available `region` values are: `China`, `Global`, `Japan`, `Korea` & `Taiwan`

Tweaks install message to reflect setup process.
