### PR TITLE
Add user-configurable override for anisotropic filtering

### DIFF
--- a/assets/locales/en.yml
+++ b/assets/locales/en.yml
@@ -162,6 +162,7 @@ config_editor:
   menu_open_key_set: "Press to set"
   msaa: "MSAA"
   render_scale: "Render Scale"
+  aniso_level: "Anisotropic Filtering"
 
 tl_update_dialog:
   title: "New update available"

--- a/assets/locales/es.yml
+++ b/assets/locales/es.yml
@@ -165,6 +165,7 @@ config_editor:
   menu_open_key: "Tecla para abrir menú"
   menu_open_key_set: "Establecer"
   render_scale: "Escala de renderizado"
+  aniso_level: "Filtrado anisotrópico"
 
 tl_update_dialog:
   title: "Nueva actualización disponible"

--- a/assets/locales/vi.yml
+++ b/assets/locales/vi.yml
@@ -140,6 +140,7 @@ config_editor:
   menu_open_key: "Phím tắt mở menu"
   menu_open_key_set: "Nhấn để thiết lập"
   render_scale: "Tỷ lệ kết xuất"
+  aniso_level: "Lọc dị hướng"
 
 tl_update_dialog:
   title: "Bản cập nhật mới"

--- a/assets/locales/zh-cn.yml
+++ b/assets/locales/zh-cn.yml
@@ -159,6 +159,7 @@ config_editor:
   menu_open_key: "打开菜单按键"
   menu_open_key_set: "按下以设置"
   render_scale: "渲染比例"
+  aniso_level: "各向异性过滤"
 
 tl_update_dialog:
   title: "新翻译更新可用"

--- a/assets/locales/zh-tw.yml
+++ b/assets/locales/zh-tw.yml
@@ -146,6 +146,7 @@ config_editor:
   menu_open_key: "選單開啟熱鍵"
   menu_open_key_set: "按下按鍵進行設定"
   render_scale: "渲染比例"
+  aniso_level: "各向異性過濾"
 
 tl_update_dialog:
   title: "有可用的更新"

--- a/src/core/gui.rs
+++ b/src/core/gui.rs
@@ -8,7 +8,7 @@ use chrono::{Utc, Datelike};
 use crate::il2cpp::{
     hook::{
         umamusume::{CySpringController::SpringUpdateMode, GameSystem, GraphicSettings::{GraphicsQuality, MsaaQuality}, Localize},
-        UnityEngine_CoreModule::Application
+        UnityEngine_CoreModule::{Application, Texture::AnisoLevel}
     },
     symbols::Thread
 };
@@ -1130,6 +1130,16 @@ impl ConfigEditor {
                     (MsaaQuality::_2x, "2x"),
                     (MsaaQuality::_4x, "4x"),
                     (MsaaQuality::_8x, "8x")
+                ]);
+                ui.end_row();
+
+                ui.label(t!("config_editor.aniso_level"));
+                Gui::run_combo(ui, "aniso_level", &mut config.aniso_level, &[
+                    (AnisoLevel::Default, &t!("default")),
+                    (AnisoLevel::_2x, "2x"),
+                    (AnisoLevel::_4x, "4x"),
+                    (AnisoLevel::_8x, "8x"),
+                    (AnisoLevel::_16x, "16x")
                 ]);
                 ui.end_row();
 

--- a/src/core/hachimi.rs
+++ b/src/core/hachimi.rs
@@ -284,6 +284,8 @@ pub struct Config {
     #[serde(default)]
     pub msaa: crate::il2cpp::hook::umamusume::GraphicSettings::MsaaQuality,
     #[serde(default)]
+    pub aniso_level: crate::il2cpp::hook::UnityEngine_CoreModule::Texture::AnisoLevel,
+    #[serde(default)]
     pub graphics_quality: crate::il2cpp::hook::umamusume::GraphicSettings::GraphicsQuality,
     #[serde(default = "Config::default_story_choice_auto_select_delay")]
     pub story_choice_auto_select_delay: f32,

--- a/src/il2cpp/hook/UnityEngine_CoreModule/Texture.rs
+++ b/src/il2cpp/hook/UnityEngine_CoreModule/Texture.rs
@@ -1,4 +1,25 @@
-use crate::il2cpp::{api::il2cpp_resolve_icall, types::*};
+use serde::{Serialize, Deserialize};
+
+use crate::{core::Hachimi, il2cpp::{api::il2cpp_resolve_icall, types::*}};
+
+// only bilinear is used in stock game
+#[allow(dead_code)]
+#[repr(i32)]
+enum FilterMode {
+    Point,
+    Bilinear,
+    Trilinear
+}
+
+#[derive(Default, Copy, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[repr(i32)]
+pub enum AnisoLevel {
+    #[default] Default,
+    _2x = 2,
+    _4x = 4,
+    _8x = 8,
+    _16x = 16
+}
 
 static mut GETDATAWIDTH_ADDR: usize = 0;
 impl_addr_wrapper_fn!(GetDataWidth, GETDATAWIDTH_ADDR, i32, this: *mut Il2CppObject);
@@ -7,24 +28,24 @@ static mut GETDATAHEIGHT_ADDR: usize = 0;
 impl_addr_wrapper_fn!(GetDataHeight, GETDATAHEIGHT_ADDR, i32, this: *mut Il2CppObject);
 
 static mut SETANISOLEVEL_ADDR: usize = 0;
-impl_addr_wrapper_fn!(SetAnisoLevel, SETANISOLEVEL_ADDR, (), this: *mut Il2CppObject, anisoLevel: i32);
+impl_addr_wrapper_fn!(SetAnisoLevel, SETANISOLEVEL_ADDR, (), this: *mut Il2CppObject, anisoLevel: AnisoLevel);
 
-#[repr(i32)]
-enum FilterMode {
-    Point,
-    Bilinear,
-    Trilinear
-}
-
+#[allow(non_camel_case_types)]
 type set_filterModeFn = extern "C" fn(this: *mut Il2CppObject, filterMode: FilterMode);
 extern "C" fn set_filterMode(this: *mut Il2CppObject, filterMode: FilterMode) {
+    let level = Hachimi::instance().config.load().aniso_level;
+    if level == AnisoLevel::Default {
+        return get_orig_fn!(set_filterMode, set_filterModeFn)(this, filterMode);
+    }
+
+    // Unity sets Trilinear by default when anisotropic is enabled
     get_orig_fn!(set_filterMode, set_filterModeFn)(this, FilterMode::Trilinear);
-    SetAnisoLevel(this, 16);
+    SetAnisoLevel(this, level);
 }
 
 pub fn init(_UnityEngine_CoreModule: *const Il2CppImage) {
     let set_filterMode_addr = il2cpp_resolve_icall(
-        c"UnityEngine.Texture::set_filterMode(System.Int32)".as_ptr()
+        c"UnityEngine.Texture::set_filterMode(UnityEngine.FilterMode)".as_ptr()
     );
 
     unsafe {


### PR DESCRIPTION
msaa done so why not texture filtering too
accomplished by hooking UnityEngine.Texture::set_FilterMode

needs more testing on android, apparently some (much older) devices can have issues supporting AF beyond 2x