### PR TITLE
build: Update installer to latest release w/ Global support

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build Installer
         run: |
-          git clone --depth 1 --revision 552d4afe6b77925519f7b0ee81cc3ee93ce68b13 https://github.com/teiosteppa/Installer
+          git clone --depth 1 --revision 4a09d33bdda922b4f3484f47e6d209414602855f https://github.com/teiosteppa/Installer
           copy build\hachimi.dll Installer
           move Cellar\build\cellar.dll Installer
           move FunnyHoney\FunnyHoney.exe Installer


### PR DESCRIPTION
I'm tagging the releases on the installer repo now, so updated to use the `--branch` arg instead of `--revision`

Latest changes strip requirement for admin privileges, add auto-detection of target by manual path (thanks @Mario0051), and a third target for the global release of the game (Steam only, just skips the binary patch step)
