### PR TITLE
Crash fixes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "log",
  "memmap2",
  "minhook",
+ "once_cell",
  "pelite",
  "png 0.17.16",
  "procfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "hachimi"
 crate-type = ["cdylib"]
 
 [profile.release]
-opt-level = "z"
+opt-level = 3
 strip = true
 lto = "fat"
 codegen-units = 1
@@ -20,6 +20,7 @@ debug = "limited"
 [dependencies]
 log = "0.4"
 cstr = "0.2"
+once_cell = "1.19"
 chrono = "0.4.42"
 arc-swap = "1.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/android/dex_bridge.rs
+++ b/src/android/dex_bridge.rs
@@ -8,7 +8,7 @@ use jni::{
     objects::{GlobalRef, JClass, JObject, JValue},
     JNIEnv,
 };
-use std::sync::LazyLock;
+use once_cell::sync::Lazy;
 
 use crate::android::main::java_vm;
 
@@ -28,7 +28,7 @@ struct DexEntry {
 }
 
 static NEXT_HANDLE: AtomicU64 = AtomicU64::new(1);
-static DEX_REGISTRY: LazyLock<Mutex<HashMap<u64, DexEntry>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+static DEX_REGISTRY: Lazy<Mutex<HashMap<u64, DexEntry>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 fn get_activity<'a>(env: &mut JNIEnv<'a>) -> Option<JObject<'a>> {
     let activity_thread_class = env.find_class("android/app/ActivityThread").ok()?;

--- a/src/android/gui_impl/input_hook.rs
+++ b/src/android/gui_impl/input_hook.rs
@@ -1,7 +1,7 @@
 use crate::android::utils::get_activity;
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, Mutex};
 use std::time::{Instant, Duration};
 
 use egui::Vec2;
@@ -34,8 +34,8 @@ const DOUBLE_TAP_WINDOW: Duration = Duration::from_millis(300);
 
 static VOLUME_UP_PRESSED: AtomicBool = AtomicBool::new(false);
 static VOLUME_DOWN_PRESSED: AtomicBool = AtomicBool::new(false);
-static VOLUME_UP_LAST_TAP: LazyLock<Arc<Mutex<Option<Instant>>>> = 
-    LazyLock::new(|| Arc::new(Mutex::new(None)));
+static VOLUME_UP_LAST_TAP: once_cell::sync::Lazy<Arc<Mutex<Option<Instant>>>> = 
+    once_cell::sync::Lazy::new(|| Arc::new(Mutex::new(None)));
 
 static SCROLL_AXIS_SCALE: f32 = 10.0;
 

--- a/src/android/main.rs
+++ b/src/android/main.rs
@@ -1,5 +1,6 @@
-use std::{ffi::CStr, os::raw::c_void, sync::OnceLock};
+use std::{ffi::CStr, os::raw::c_void};
 use jni::{sys::jint, JavaVM};
+use once_cell::sync::OnceCell;
 
 use crate::core::Hachimi;
 
@@ -11,7 +12,7 @@ type JniOnLoadFn = extern "C" fn(vm: JavaVM, reserved: *mut c_void) -> jint;
 const LIBRARY_NAME: &CStr = c"libmain_orig.so";
 const JNI_ONLOAD_NAME: &CStr = c"JNI_OnLoad";
 
-static JAVA_VM: OnceLock<JavaVM> = OnceLock::new();
+static JAVA_VM: OnceCell<JavaVM> = OnceCell::new();
 
 pub(crate) fn java_vm() -> Option<&'static JavaVM> {
     JAVA_VM.get()

--- a/src/core/gui.rs
+++ b/src/core/gui.rs
@@ -4,13 +4,14 @@ use std::{
     ops::RangeInclusive,
     os::raw::c_void,
     panic::{self, AssertUnwindSafe},
-    sync::{atomic::{self, AtomicBool}, Arc, LazyLock, Mutex, OnceLock},
+    sync::{atomic::{self, AtomicBool}, Arc, Mutex},
     thread,
     time::Instant
 };
 
 use egui_scale::EguiScale;
 use fnv::FnvHashSet;
+use once_cell::sync::{Lazy, OnceCell};
 use rust_i18n::t;
 use chrono::{Utc, Datelike};
 
@@ -100,14 +101,14 @@ pub struct Gui {
 
 const PIXELS_PER_POINT_RATIO: f32 = 3.0/1080.0;
 
-static INSTANCE: OnceLock<Mutex<Gui>> = OnceLock::new();
+static INSTANCE: OnceCell<Mutex<Gui>> = OnceCell::new();
 static IS_CONSUMING_INPUT: AtomicBool = AtomicBool::new(false);
-static DISABLED_GAME_UIS: LazyLock<Mutex<FnvHashSet<SendPtr>>> =
-    LazyLock::new(|| Mutex::new(FnvHashSet::default()));
-static PLUGIN_MENU_ITEMS: LazyLock<Mutex<Vec<PluginMenuItem>>> = LazyLock::new(|| Mutex::new(Vec::new()));
-static PLUGIN_MENU_SECTIONS: LazyLock<Mutex<Vec<PluginMenuSection>>> = LazyLock::new(|| Mutex::new(Vec::new()));
-static PLUGIN_MENU_ICONS: LazyLock<Mutex<HashMap<String, PluginMenuIcon>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
-static PLUGIN_NOTIFICATIONS: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+static DISABLED_GAME_UIS: Lazy<Mutex<FnvHashSet<SendPtr>>> =
+    Lazy::new(|| Mutex::new(FnvHashSet::default()));
+static PLUGIN_MENU_ITEMS: Lazy<Mutex<Vec<PluginMenuItem>>> = Lazy::new(|| Mutex::new(Vec::new()));
+static PLUGIN_MENU_SECTIONS: Lazy<Mutex<Vec<PluginMenuSection>>> = Lazy::new(|| Mutex::new(Vec::new()));
+static PLUGIN_MENU_ICONS: Lazy<Mutex<HashMap<String, PluginMenuIcon>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static PLUGIN_NOTIFICATIONS: Lazy<Mutex<Vec<String>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
 pub type PluginMenuCallback = extern "C" fn(userdata: *mut c_void);
 pub type PluginMenuSectionCallback = extern "C" fn(ui: *mut c_void, userdata: *mut c_void);
@@ -212,14 +213,14 @@ static PENDING_KEYBOARD_TEXT: AtomicPtr<Il2CppString> = AtomicPtr::new(std::ptr:
 #[cfg(target_os = "android")]
 static ACTIVE_KEYBOARD: AtomicPtr<Il2CppObject> = AtomicPtr::new(std::ptr::null_mut());
 #[cfg(target_os = "android")]
-pub static KEYBOARD_GC_HANDLE: LazyLock<Mutex<Option<GCHandle>>> = LazyLock::new(|| Mutex::default());
+pub static KEYBOARD_GC_HANDLE: Lazy<Mutex<Option<GCHandle>>> = Lazy::new(|| Mutex::default());
 #[cfg(target_os = "android")]
-static KEYBOARD_SELECTION: LazyLock<Mutex<RangeInt>> = LazyLock::new(|| {
+static KEYBOARD_SELECTION: Lazy<Mutex<RangeInt>> = Lazy::new(|| {
     Mutex::new(RangeInt::new(0, 1))
 });
 #[cfg(target_os = "android")]
-pub static KEYBOARD_OWNER: LazyLock<Mutex<Option<KeyboardOwner>>> = 
-    LazyLock::new(|| Mutex::new(None));
+pub static KEYBOARD_OWNER: Lazy<Mutex<Option<KeyboardOwner>>> = 
+    Lazy::new(|| Mutex::new(None));
 #[cfg(target_os = "android")]
 #[derive(PartialEq)]
 pub enum KeyboardOwner {

--- a/src/core/hachimi.rs
+++ b/src/core/hachimi.rs
@@ -1,6 +1,7 @@
-use std::{fs, path::{Path, PathBuf}, process, sync::{atomic::{self, AtomicBool, AtomicI32}, Arc, Mutex, OnceLock}};
+use std::{fs, path::{Path, PathBuf}, process, sync::{atomic::{self, AtomicBool, AtomicI32}, Arc, Mutex}};
 use arc_swap::ArcSwap;
 use fnv::{FnvHashMap, FnvHashSet};
+use once_cell::sync::OnceCell;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use textwrap::wrap_algorithms::Penalties;
 
@@ -52,7 +53,7 @@ pub struct Hachimi {
     pub updater: Arc<updater::Updater>
 }
 
-static INSTANCE: OnceLock<Arc<Hachimi>> = OnceLock::new();
+static INSTANCE: OnceCell<Arc<Hachimi>> = OnceCell::new();
 
 impl Hachimi {
     pub fn init() -> bool {

--- a/src/core/plugin_api.rs
+++ b/src/core/plugin_api.rs
@@ -1,12 +1,13 @@
-use std::{ffi::{c_char, c_void, CStr}, sync::OnceLock};
+use std::ffi::{c_char, c_void, CStr};
 
+use once_cell::sync::OnceCell;
 use egui::Align;
 
 use crate::{core::{gui, Hachimi, Interceptor}, il2cpp::{self, types::{il2cpp_array_size_t, FieldInfo, Il2CppArray, Il2CppClass, Il2CppImage, Il2CppObject, Il2CppThread, Il2CppTypeEnum, MethodInfo}}};
 
 const VERSION: i32 = 2;
 
-static PLUGIN_VTABLE: OnceLock<Vtable> = OnceLock::new();
+static PLUGIN_VTABLE: OnceCell<Vtable> = OnceCell::new();
 
 pub type HachimiInitFn = extern "C" fn(vtable: *const Vtable, version: i32) -> InitResult;
 pub type GuiMenuCallback = extern "C" fn(userdata: *mut c_void);

--- a/src/core/sugoi_client.rs
+++ b/src/core/sugoi_client.rs
@@ -1,5 +1,6 @@
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
+use once_cell::sync::Lazy;
 use serde::Serialize;
 
 use super::{Error, Hachimi};
@@ -9,7 +10,7 @@ pub struct SugoiClient {
     url: String
 }
 
-static INSTANCE: LazyLock<Arc<SugoiClient>> = LazyLock::new(|| {
+static INSTANCE: Lazy<Arc<SugoiClient>> = Lazy::new(|| {
     Arc::new(SugoiClient {
         agent: ureq::Agent::new(),
         url: Hachimi::instance().config.load().sugoi_url.as_ref()

--- a/src/core/tl_repo.rs
+++ b/src/core/tl_repo.rs
@@ -9,7 +9,7 @@ use thread_priority::{ThreadBuilderExt, ThreadPriority};
 
 use crate::core::game::Region;
 use super::{gui::SimpleYesNoDialog, hachimi::LocalizedData, http::{self, AsyncRequest}, utils, Error, Gui, Hachimi};
-use std::sync::LazyLock;
+use once_cell::sync::Lazy;
 
 #[derive(Deserialize)]
 pub struct RepoInfo {
@@ -129,7 +129,7 @@ pub struct Updater {
 
 const LOCALIZED_DATA_DIR: &str = "localized_data";
 const CHUNK_SIZE: usize = 8192; // 8KiB
-static NUM_THREADS: LazyLock<usize> = LazyLock::new(|| {
+static NUM_THREADS: Lazy<usize> = Lazy::new(|| {
     let parallelism = thread::available_parallelism().unwrap().get();
     max(1, parallelism / 2)
 });

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,9 +1,10 @@
-use std::{borrow::Cow, fs::File, io::Write, sync::{LazyLock, Mutex}, path::Path, time::SystemTime};
+use std::{borrow::Cow, fs::File, io::Write, sync::Mutex, path::Path, time::SystemTime};
 
 use serde::Serialize;
 use textwrap::{core::Word, wrap_algorithms, WordSeparator::UnicodeBreakProperties};
 use unicode_width::UnicodeWidthChar;
 use fnv::FnvHashMap;
+use once_cell::sync::Lazy;
 
 use crate::{core::Gui, il2cpp::{ext::{Il2CppStringExt, StringExt}, hook::umamusume::{Localize, TextId}, types::{Il2CppObject, Il2CppString}, symbols::Thread}};
 
@@ -16,8 +17,8 @@ pub struct SendPtr(pub *mut Il2CppObject);
 unsafe impl Send for SendPtr {}
 unsafe impl Sync for SendPtr {}
 
-static LOCALIZE_ID_CACHE: LazyLock<Mutex<FnvHashMap<String, i32>>> = 
-    LazyLock::new(|| Mutex::new(FnvHashMap::default()));
+static LOCALIZE_ID_CACHE: Lazy<Mutex<FnvHashMap<String, i32>>> = 
+    Lazy::new(|| Mutex::new(FnvHashMap::default()));
 
 pub fn get_localized_string(id_name: &str) -> String {
     let check_cache = |name: &str| -> Option<String> {

--- a/src/il2cpp/api.rs
+++ b/src/il2cpp/api.rs
@@ -1,11 +1,11 @@
 /* generated for 2022.3.20f1 */
 #![allow(non_upper_case_globals)]
 use super::{symbols, types::*};
-use std::sync::LazyLock;
+use once_cell::sync::Lazy;
 
 macro_rules! lazy_fnptr {
     ($name:tt, $ret:ty, $($v:ident: $t:ty),*) => {
-        pub static $name: LazyLock<extern "C" fn($($v: $t),*) -> $ret> = LazyLock::new(||
+        pub static $name: Lazy<extern "C" fn($($v: $t),*) -> $ret> = Lazy::new(||
             unsafe { std::mem::transmute(symbols::dlsym(stringify!($name))) }
         );
     }

--- a/src/il2cpp/ext.rs
+++ b/src/il2cpp/ext.rs
@@ -1,7 +1,7 @@
 use std::{hash::Hasher, sync::Mutex};
 
 use fnv::FnvHasher;
-use std::sync::LazyLock;
+use once_cell::sync::Lazy;
 use widestring::{Utf16Str, Utf16String};
 
 use crate::core::hachimi::LocalizedData;
@@ -40,9 +40,9 @@ pub trait LocalizedDataExt {
     fn load_tmp_replacement_font(&self) -> *mut Il2CppObject;
 }
 
-static EXTRA_ASSET_BUNDLE_HANDLE: LazyLock<Mutex<Option<GCHandle>>> = LazyLock::new(|| Mutex::default());
-static REPLACEMENT_FONT_HANDLE: LazyLock<Mutex<Option<GCHandle>>> = LazyLock::new(|| Mutex::default());
-static TMP_REPLACEMENT_FONT_HANDLE: LazyLock<Mutex<Option<GCHandle>>> = LazyLock::new(|| Mutex::default());
+static EXTRA_ASSET_BUNDLE_HANDLE: Lazy<Mutex<Option<GCHandle>>> = Lazy::new(|| Mutex::default());
+static REPLACEMENT_FONT_HANDLE: Lazy<Mutex<Option<GCHandle>>> = Lazy::new(|| Mutex::default());
+static TMP_REPLACEMENT_FONT_HANDLE: Lazy<Mutex<Option<GCHandle>>> = Lazy::new(|| Mutex::default());
 
 impl LocalizedDataExt for LocalizedData {
     fn load_extra_asset_bundle(&self) -> *mut Il2CppObject {

--- a/src/il2cpp/hook/LibNative_Runtime/Sqlite3/Connection.rs
+++ b/src/il2cpp/hook/LibNative_Runtime/Sqlite3/Connection.rs
@@ -1,6 +1,7 @@
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
 
 use fnv::FnvHashMap;
+use once_cell::sync::Lazy;
 use sqlparser::{
     ast::BinaryOperator,
     dialect::SQLiteDialect,
@@ -27,8 +28,8 @@ pub fn new() -> *mut Il2CppObject {
     object
 }
 
-pub static SELECT_QUERIES: LazyLock<Mutex<FnvHashMap<usize, Box<dyn sql::SelectQueryState + Send + Sync>>>> =
-    LazyLock::new(|| Mutex::new(FnvHashMap::default()));
+pub static SELECT_QUERIES: Lazy<Mutex<FnvHashMap<usize, Box<dyn sql::SelectQueryState + Send + Sync>>>> =
+    Lazy::new(|| Mutex::new(FnvHashMap::default()));
 
 #[inline(never)]
 fn parse_query(query: *mut Il2CppObject, sql: *const Il2CppString) {

--- a/src/il2cpp/hook/UnityEngine_AssetBundleModule/AssetBundle.rs
+++ b/src/il2cpp/hook/UnityEngine_AssetBundleModule/AssetBundle.rs
@@ -1,6 +1,7 @@
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
 
 use fnv::FnvHashMap;
+use once_cell::sync::Lazy;
 use widestring::Utf16Str;
 
 use crate::{core::{ext::Utf16StringExt, hachimi::AssetMetadata}, il2cpp::{
@@ -22,9 +23,9 @@ impl RequestInfo {
         self.name_handle.target() as _
     }
 }
-pub static REQUEST_INFOS: LazyLock<Mutex<FnvHashMap<usize, RequestInfo>>> = LazyLock::new(|| Mutex::default());
+pub static REQUEST_INFOS: Lazy<Mutex<FnvHashMap<usize, RequestInfo>>> = Lazy::new(|| Mutex::default());
 
-static BUNDLE_PATHS: LazyLock<Mutex<FnvHashMap<usize, GCHandle>>> = LazyLock::new(|| Mutex::default());
+static BUNDLE_PATHS: Lazy<Mutex<FnvHashMap<usize, GCHandle>>> = Lazy::new(|| Mutex::default());
 pub fn get_bundle_path(this: *mut Il2CppObject) -> Option<*mut Il2CppString> {
     Some(BUNDLE_PATHS.lock().unwrap().get(&(this as usize))?.target() as _)
 }

--- a/src/il2cpp/hook/umamusume/PartsSingleModeSkillListItem.rs
+++ b/src/il2cpp/hook/umamusume/PartsSingleModeSkillListItem.rs
@@ -2,11 +2,12 @@ use crate::{
     core::{Hachimi, game::Region, utils::{mul_int, str_visual_len}},
     il2cpp::{ext::{Il2CppStringExt, StringExt}, hook::{UnityEngine_CoreModule::{Component, Object, UnityAction}, UnityEngine_UI::{EventSystem, Text}}, sql::{self, TextDataQuery}, symbols::{create_delegate, get_field_from_name, get_field_object_value, get_method_addr}, types::*}
 };
-use std::sync::{LazyLock, Mutex};
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
 use fnv::FnvHashMap;
 use super::{ButtonCommon, DialogCommon, DialogManager, MasterDataUtil};
 
-static SKILL_TEXT_CACHE: LazyLock<Mutex<FnvHashMap<i32, (String, String)>>> = LazyLock::new(|| Mutex::default());
+static SKILL_TEXT_CACHE: Lazy<Mutex<FnvHashMap<i32, (String, String)>>> = Lazy::new(|| Mutex::default());
 
 // SkillListItem
 static mut NAMETEXT_FIELD: *mut FieldInfo = 0 as _;

--- a/src/il2cpp/hook/umamusume/TextFrame.rs
+++ b/src/il2cpp/hook/umamusume/TextFrame.rs
@@ -1,13 +1,14 @@
-use std::{collections::hash_map, sync::{LazyLock, Mutex}};
+use std::{collections::hash_map, sync::Mutex};
 
 use fnv::FnvHashMap;
+use once_cell::sync::Lazy;
 
 use crate::{core::Hachimi, il2cpp::{hook::UnityEngine_UI::Text, symbols::{get_method_addr, GCHandle}, types::*}};
 
 static mut GET_TEXTLABEL_ADDR: usize = 0;
 impl_addr_wrapper_fn!(get_TextLabel, GET_TEXTLABEL_ADDR, *mut Il2CppObject, this: *mut Il2CppObject);
 
-pub static PROCESSED: LazyLock<Mutex<FnvHashMap<usize, GCHandle>>> = LazyLock::new(|| Mutex::default());
+pub static PROCESSED: Lazy<Mutex<FnvHashMap<usize, GCHandle>>> = Lazy::new(|| Mutex::default());
 
 type InitializeFn = extern "C" fn(this: *mut Il2CppObject);
 extern "C" fn Initialize(this: *mut Il2CppObject) {

--- a/src/il2cpp/symbols.rs
+++ b/src/il2cpp/symbols.rs
@@ -4,9 +4,10 @@ use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::os::raw::c_void;
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
 
 use fnv::FnvHashMap;
+use once_cell::sync::Lazy;
 
 use crate::core::Hachimi;
 use crate::symbols_impl;
@@ -124,9 +125,9 @@ pub fn get_method_overload_addr(class: *mut Il2CppClass, name: &str, params: &[I
     }
 }
 
-pub static METHOD_CACHE: LazyLock<
+pub static METHOD_CACHE: Lazy<
     Mutex<FnvHashMap<usize, FnvHashMap<(Cow<'_, CStr>, i32), usize>>>
-> = LazyLock::new(|| Mutex::default());
+> = Lazy::new(|| Mutex::default());
 
 pub fn get_method_cached(class: *mut Il2CppClass, name: &CStr, args_count: i32) -> Result<*const MethodInfo, Error> {
     let mut cache = METHOD_CACHE.lock().unwrap();

--- a/src/windows/discord.rs
+++ b/src/windows/discord.rs
@@ -1,11 +1,12 @@
 use std::{
-    sync::{LazyLock, Mutex},
+    sync::Mutex,
     time::{SystemTime, UNIX_EPOCH}
 };
+use once_cell::sync::Lazy;
 use discord_rich_presence::{activity::{Activity, ActivityType, Assets, Timestamps}, DiscordIpc, DiscordIpcClient};
 use crate::core::Error;
 
-static DISCORD_CLIENT: LazyLock<Mutex<Option<DiscordIpcClient>>> = LazyLock::new(|| {
+static DISCORD_CLIENT: Lazy<Mutex<Option<DiscordIpcClient>>> = Lazy::new(|| {
     Mutex::new(None)
 });
 

--- a/src/windows/gui_impl/render_hook.rs
+++ b/src/windows/gui_impl/render_hook.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
-use std::{os::raw::{c_uint, c_void}, sync::{OnceLock, Mutex}};
+use std::{os::raw::{c_uint, c_void}, sync::Mutex};
 
+use once_cell::sync::OnceCell;
 use windows::{
     core::{w, Interface, HRESULT},
     Win32::{
@@ -152,7 +153,7 @@ extern "C" fn IDXGISwapChain_ResizeBuffers(
     ))
 }
 
-static PAINTER: OnceLock<Mutex<D3D11Painter>> = OnceLock::new();
+static PAINTER: OnceCell<Mutex<D3D11Painter>> = OnceCell::new();
 fn init_painter(p_swap_chain: *mut c_void) -> Result<&'static Mutex<D3D11Painter>, Error> {
     // TODO: use get_or_try_init again once it's in stable
     if let Some(painter) = PAINTER.get() {

--- a/src/windows/symbols_impl.rs
+++ b/src/windows/symbols_impl.rs
@@ -1,5 +1,6 @@
-use std::{ffi::{CStr, CString}, os::raw::c_void, sync::LazyLock};
+use std::{ffi::{CStr, CString}, os::raw::c_void};
 use fnv::FnvHashMap;
+use once_cell::sync::Lazy;
 use pelite::{pe::Pe, pe64::PeFile, FileMap};
 use windows::Win32::Foundation::HMODULE;
 
@@ -271,7 +272,7 @@ impl From<pelite::Error> for Error {
     }
 }
 
-static SYMBOL_MAP: LazyLock<FnvHashMap<&'static str, CString>> = LazyLock::new(|| {
+static SYMBOL_MAP: Lazy<FnvHashMap<&'static str, CString>> = Lazy::new(|| {
     match generate_symbol_map() {
         Ok(v) => v,
         Err(e) => {


### PR DESCRIPTION
- Revert replacement of `once_cell` with Rust's standard library equivalents.
- Set `opt-level` to `3` to workaround `ScaleToScreenSize` crashes.