### PR TITLE
Fix some formatting templates in event outcomes

### DIFF
--- a/src/il2cpp/hook/umamusume/PartsSingleModeChoiceRewardTextElementViewModel.rs
+++ b/src/il2cpp/hook/umamusume/PartsSingleModeChoiceRewardTextElementViewModel.rs
@@ -1,0 +1,38 @@
+use crate::{
+    core::Hachimi,
+    il2cpp::{
+        ext::{Il2CppStringExt, StringExt},
+        hook::UnityEngine_TextRenderingModule::TextGenerator::IgnoreTGFiltersContext,
+        symbols::get_method_addr,
+        types::{Il2CppImage, Il2CppObject, Il2CppString},
+    },
+};
+
+type GetParameterValueTextFn =
+    extern "C" fn(this: *mut Il2CppObject, param: i32) -> *mut Il2CppString;
+extern "C" fn GetParameterValueText(this: *mut Il2CppObject, param: i32) -> *mut Il2CppString {
+    let mut text = get_orig_fn!(GetParameterValueText, GetParameterValueTextFn)(this, param);
+    let utf_str = unsafe { (*text).as_utf16str() };
+    if utf_str.as_slice().contains(&36) {
+        text = Hachimi::instance()
+            .template_parser
+            .eval_with_context(&utf_str.to_string(), &mut IgnoreTGFiltersContext())
+            .to_il2cpp_string();
+    }
+    text
+}
+
+pub fn init(umamusume: *const Il2CppImage) {
+    get_class_or_return!(
+        umamusume,
+        Gallop,
+        PartsSingleModeChoiceRewardTextElementViewModel
+    );
+
+    let GetParameterValueText_addr = get_method_addr(
+        PartsSingleModeChoiceRewardTextElementViewModel,
+        c"GetParameterValueText",
+        1,
+    );
+    new_hook!(GetParameterValueText_addr, GetParameterValueText);
+}

--- a/src/il2cpp/hook/umamusume/mod.rs
+++ b/src/il2cpp/hook/umamusume/mod.rs
@@ -70,6 +70,7 @@ mod LowResolutionCamera;
 pub mod TweenAnimationTimelineComponent;
 pub mod TweenAnimationTimelineData;
 pub mod TweenAnimationTimelineSheetData;
+mod PartsSingleModeChoiceRewardTextElementViewModel;
 
 pub fn init() {
     get_assembly_image_or_return!(image, "umamusume.dll");
@@ -145,4 +146,5 @@ pub fn init() {
     TweenAnimationTimelineComponent::init(image);
     TweenAnimationTimelineData::init(image);
     TweenAnimationTimelineSheetData::init(image);
+    PartsSingleModeChoiceRewardTextElementViewModel::init(image);
 }


### PR DESCRIPTION
Fixes part of #48. It's the same underlying cause as in [TrainingParamChangePlate](https://github.com/kairusds/Hachimi-Edge/blob/46d8ec24a16e520fe2ca3ca6a566a78c1b4bdf8f/src/il2cpp/hook/umamusume/TrainingParamChangePlate.rs#L8).

Thanks to Jack for helping to track it down, expecting a PR from him to fix the other part of the linked issue.