### PR TITLE
Ignore TL repo filters in PartsCommonHeaderTitle text fields

### DIFF
--- a/src/il2cpp/hook/umamusume/PartsCommonHeaderTitle/TitlePlayer.rs
+++ b/src/il2cpp/hook/umamusume/PartsCommonHeaderTitle/TitlePlayer.rs
@@ -1,0 +1,32 @@
+use crate::{
+    core::Hachimi,
+    il2cpp::{
+        ext::{Il2CppStringExt, StringExt},
+        hook::UnityEngine_TextRenderingModule::TextGenerator::IgnoreTGFiltersContext,
+        symbols::get_method_addr,
+        types::{Il2CppClass, Il2CppObject, Il2CppString},
+    },
+};
+
+type SetTextFn = extern "C" fn(this: *mut Il2CppObject, text: *mut Il2CppString);
+extern "C" fn SetText(this: *mut Il2CppObject, text: *mut Il2CppString) {
+    let utf_str = unsafe { (*text).as_utf16str() };
+    // doesn't run through TextGenerator, ignore its filters
+    // 36 = dollar sign ($)
+    if !text.is_null() && utf_str.as_slice().contains(&36) {
+        let clean_text = Hachimi::instance()
+            .template_parser
+            .eval_with_context(&utf_str.to_string(), &mut IgnoreTGFiltersContext());
+        return get_orig_fn!(SetText, SetTextFn)(this, clean_text.to_il2cpp_string());
+    }
+
+    get_orig_fn!(SetText, SetTextFn)(this, text);
+}
+
+pub fn init(PartsCommonHeaderTitle: *mut Il2CppClass) {
+    find_nested_class_or_return!(PartsCommonHeaderTitle, TitlePlayer);
+
+    let SetText_addr = get_method_addr(TitlePlayer, c"SetText", 1);
+
+    new_hook!(SetText_addr, SetText);
+}

--- a/src/il2cpp/hook/umamusume/PartsCommonHeaderTitle/mod.rs
+++ b/src/il2cpp/hook/umamusume/PartsCommonHeaderTitle/mod.rs
@@ -1,0 +1,9 @@
+mod TitlePlayer;
+
+use crate::il2cpp::types::*;
+
+pub fn init(umamusume: *const Il2CppImage) {
+    get_class_or_return!(umamusume, Gallop, PartsCommonHeaderTitle);
+    
+    TitlePlayer::init(PartsCommonHeaderTitle);
+}

--- a/src/il2cpp/hook/umamusume/mod.rs
+++ b/src/il2cpp/hook/umamusume/mod.rs
@@ -71,6 +71,7 @@ pub mod TweenAnimationTimelineComponent;
 pub mod TweenAnimationTimelineData;
 pub mod TweenAnimationTimelineSheetData;
 mod PartsSingleModeChoiceRewardTextElementViewModel;
+mod PartsCommonHeaderTitle;
 
 pub fn init() {
     get_assembly_image_or_return!(image, "umamusume.dll");
@@ -147,4 +148,5 @@ pub fn init() {
     TweenAnimationTimelineData::init(image);
     TweenAnimationTimelineSheetData::init(image);
     PartsSingleModeChoiceRewardTextElementViewModel::init(image);
+    PartsCommonHeaderTitle::init(image);
 }


### PR DESCRIPTION
closes #48 (mostly) along with Noccu's recent change to outcomes
allows for some more usage of $() filters in localize_dict without causing additional conflicts elsewhere (mostly in menu title banners)