### PR TITLE
Apply position offset to animated sprites

### DIFF
--- a/src/il2cpp/hook/Plugins/AnimateToUnity/AnKeyParameter.rs
+++ b/src/il2cpp/hook/Plugins/AnimateToUnity/AnKeyParameter.rs
@@ -1,0 +1,17 @@
+use crate::il2cpp::{
+    symbols::{get_field_from_name, get_field_object_value},
+    types::*,
+};
+
+static mut _KEY_LIST_FIELD: *mut FieldInfo = 0 as _;
+pub fn get__keyList(this: *mut Il2CppObject) -> *mut Il2CppObject {
+    get_field_object_value(this, unsafe { _KEY_LIST_FIELD })
+}
+
+pub fn init(Plugins: *const Il2CppImage) {
+    get_class_or_return!(Plugins, AnimateToUnity, AnKeyParameter);
+
+    unsafe {
+        _KEY_LIST_FIELD = get_field_from_name(AnKeyParameter, c"_keyList");
+    }
+}

--- a/src/il2cpp/hook/Plugins/AnimateToUnity/AnObjectParameterBase.rs
+++ b/src/il2cpp/hook/Plugins/AnimateToUnity/AnObjectParameterBase.rs
@@ -1,4 +1,7 @@
-use crate::il2cpp::{symbols::{get_field_from_name, set_field_value}, types::*};
+use crate::il2cpp::{
+    symbols::{get_field_from_name, get_field_object_value, set_field_value},
+    types::*,
+};
 
 static mut _POSITIONOFFSET_FIELD: *mut FieldInfo = 0 as _;
 pub fn set__positionOffset(this: *mut Il2CppObject, value: &Vector3_t) {
@@ -8,7 +11,12 @@ pub fn set__positionOffset(this: *mut Il2CppObject, value: &Vector3_t) {
 static mut _SCALE_FIELD: *mut FieldInfo = 0 as _;
 pub fn set__scale(this: *mut Il2CppObject, value: &Vector3_t) {
     set_field_value(this, unsafe { _SCALE_FIELD }, value);
-}                               
+}
+
+static mut _POSITIONOFFSET_KEYPARAM_LIST_FIELD: *mut FieldInfo = 0 as _;
+pub fn get__positionOffsetKeyParamList(this: *mut Il2CppObject) -> *mut Il2CppObject {
+    get_field_object_value(this, unsafe { _POSITIONOFFSET_KEYPARAM_LIST_FIELD })
+}
 
 pub fn init(Plugins: *const Il2CppImage) {
     get_class_or_return!(Plugins, AnimateToUnity, AnObjectParameterBase);
@@ -16,5 +24,6 @@ pub fn init(Plugins: *const Il2CppImage) {
     unsafe {
         _POSITIONOFFSET_FIELD = get_field_from_name(AnObjectParameterBase, c"_positionOffset");
         _SCALE_FIELD = get_field_from_name(AnObjectParameterBase, c"_scale");
+        _POSITIONOFFSET_KEYPARAM_LIST_FIELD = get_field_from_name(AnObjectParameterBase, c"_positionOffsetKeyParamList");
     }
 }

--- a/src/il2cpp/hook/Plugins/AnimateToUnity/AnRoot.rs
+++ b/src/il2cpp/hook/Plugins/AnimateToUnity/AnRoot.rs
@@ -196,14 +196,24 @@ pub fn patch_asset(this: *mut Il2CppObject, data_opt: Option<&AnRootData>) {
                     if let Some(scale) = &plane_param_data.base.scale {
                         AnObjectParameterBase::set__scale(plane_param, scale);
                     }
-                    if let Some(anim_pos_offset) = &plane_param_data.anim_pos_offset_adj {
+                    if let Some(anim_pos_offset) = &plane_param_data.anim_pos_offset {
+                        // Count should be 3 if present, representing XYZ axes. We ignore Z.
                         if let Some(pos_offset_keyparam_list) = IList::new(AnObjectParameterBase::get__positionOffsetKeyParamList(plane_param)) {
-                            for keyparam_list in pos_offset_keyparam_list.iter() {
-                                if let Some(pos_offset_key_list) = IList::<Vector2_t>::new(AnKeyParameter::get__keyList(keyparam_list)) {
-                                    for k in 0..pos_offset_key_list.count() {
-                                        let mut key_param = pos_offset_key_list.get(k).unwrap();
-                                        key_param.y += anim_pos_offset.y;
-                                        pos_offset_key_list.set(k, key_param);
+                            if pos_offset_keyparam_list.count() > 1 {
+                                let x_axis_key_param = pos_offset_keyparam_list.get(0).unwrap();
+                                if let Some(x_axis_key_list) = IList::<Vector2_t>::new(AnKeyParameter::get__keyList(x_axis_key_param)) {
+                                    for k in 0..x_axis_key_list.count() {
+                                        let mut key_values = x_axis_key_list.get(k).unwrap();
+                                        key_values.y += anim_pos_offset.x;
+                                        x_axis_key_list.set(k, key_values);
+                                    }
+                                }
+                                let y_axis_key_param = pos_offset_keyparam_list.get(1).unwrap();
+                                if let Some(y_axis_key_list) = IList::<Vector2_t>::new(AnKeyParameter::get__keyList(y_axis_key_param)) {
+                                    for k in 0..y_axis_key_list.count() {
+                                        let mut key_values = y_axis_key_list.get(k).unwrap();
+                                        key_values.y += anim_pos_offset.y;
+                                        y_axis_key_list.set(k, key_values);
                                     }
                                 }
                             }

--- a/src/il2cpp/hook/Plugins/AnimateToUnity/AnRoot.rs
+++ b/src/il2cpp/hook/Plugins/AnimateToUnity/AnRoot.rs
@@ -7,7 +7,7 @@ use widestring::Utf16Str;
 use crate::{
     core::{ext::Utf16StringExt, hachimi::AssetInfo, Hachimi},
     il2cpp::{
-        api::{il2cpp_class_get_type, il2cpp_type_get_object}, ext::{Il2CppStringExt, StringExt}, hook::{UnityEngine_AssetBundleModule::AssetBundle, UnityEngine_CoreModule::Object}, symbols::{get_field_from_name, get_field_object_value, IList}, types::*, utils::replace_texture_with_diff
+        api::{il2cpp_class_get_type, il2cpp_type_get_object}, ext::{Il2CppStringExt, StringExt}, hook::{Plugins::AnimateToUnity::AnKeyParameter, UnityEngine_AssetBundleModule::AssetBundle, UnityEngine_CoreModule::Object}, symbols::{IList, get_field_from_name, get_field_object_value}, types::*, utils::replace_texture_with_diff
     }
 };
 
@@ -69,7 +69,8 @@ struct AnTextParameterData {
 #[derive(Deserialize)]
 struct AnPlaneParameterData {
     #[serde(flatten)]
-    base: AnObjectParameterBaseData
+    base: AnObjectParameterBaseData,
+    anim_pos_offset_adj: Option<Vector2_t>
 }
 
 pub fn on_LoadAsset(bundle: *mut Il2CppObject, this: *mut Il2CppObject, name: &Utf16Str) {
@@ -192,9 +193,24 @@ pub fn patch_asset(this: *mut Il2CppObject, data_opt: Option<&AnRootData>) {
                     if let Some(position_offset) = &plane_param_data.base.position_offset {
                         AnObjectParameterBase::set__positionOffset(plane_param, position_offset);
                     }
-                                                                        
                     if let Some(scale) = &plane_param_data.base.scale {
                         AnObjectParameterBase::set__scale(plane_param, scale);
+                    }
+                    if let Some(anim_pos_offset) = &plane_param_data.anim_pos_offset_adj {
+                        if let Some(pos_offset_keyparam_list) = IList::new(AnObjectParameterBase::get__positionOffsetKeyParamList(plane_param)) {
+                            for keyparam_list in pos_offset_keyparam_list.iter() {
+                                if let Some(pos_offset_key_list) = IList::<Vector2_t>::new(AnKeyParameter::get__keyList(keyparam_list)) {
+                                    for k in 0..pos_offset_key_list.count() {
+                                        let mut key_param = pos_offset_key_list.get(k).unwrap();
+                                        key_param.y += anim_pos_offset.y;
+                                        pos_offset_key_list.set(k, key_param);
+                                    }
+                                }
+                            }
+                        }
+                        else {
+                            warn!("Failed to get pos_offset_keyparams for plane param {} of motion param {}", *j, *i);
+                        }
                     }
                 }
             }

--- a/src/il2cpp/hook/Plugins/AnimateToUnity/mod.rs
+++ b/src/il2cpp/hook/Plugins/AnimateToUnity/mod.rs
@@ -9,6 +9,7 @@ mod AnRootParameter;
 mod AnMotionParameterGroup;
 mod AnMotionParameter;
 mod AnTextParameter;
+mod AnKeyParameter;
 mod AnObjectParameterBase;
 mod AnGlobalData;
 
@@ -22,6 +23,7 @@ pub fn init(image: *const Il2CppImage) {
     AnMotionParameterGroup::init(image);
     AnMotionParameter::init(image);
     AnTextParameter::init(image);
+    AnKeyParameter::init(image);
     AnObjectParameterBase::init(image);
     AnGlobalData::init(image);
 }

--- a/src/il2cpp/types.rs
+++ b/src/il2cpp/types.rs
@@ -2925,7 +2925,7 @@ impl Color32_t {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Deserialize)]
 pub struct Vector2_t {
     pub x: f32,
     pub y: f32,


### PR DESCRIPTION
When sprites are animated, the normal positionOffset is overridden by the animation key values.
This PR supports changing the animation key values per axis by a custom offset.

Currently these are provided separately, but I think we can merge this with the normal pos offsets instead. This would mean calculating the difference between the game's and the custom offsets and applying them to the corresponding axis keys, if present. I'm not sure if this is cleaner or more confusing, nor whether there might be edge cases where this wouldn't work correctly.