### PR TITLE
Fix race skill log names formatting

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -17,7 +17,7 @@ pub struct SendPtr(pub *mut Il2CppObject);
 unsafe impl Send for SendPtr {}
 unsafe impl Sync for SendPtr {}
 
-static LOCALIZE_ID_CACHE: Lazy<Mutex<FnvHashMap<String, i32>>> = 
+static LOCALIZE_ID_CACHE: Lazy<Mutex<FnvHashMap<String, i32>>> =
     Lazy::new(|| Mutex::new(FnvHashMap::default()));
 
 pub fn get_localized_string(id_name: &str) -> String {
@@ -61,7 +61,7 @@ pub fn char_to_utf16_index(text: &str, char_idx: usize) -> i32 {
 pub fn utf16_to_char_index(text: &str, utf16_idx: usize) -> usize {
     let mut current_utf16_pos = 0;
     let mut char_pos = 0;
-    
+
     for c in text.chars() {
         if current_utf16_pos >= utf16_idx {
             break;
@@ -448,7 +448,13 @@ pub fn wrap_fit_text(string: &str, base_line_width: i32, mut max_line_count: i32
     loop {
         let wrapped = wrap_text_internal(string, line_width.round() as i32, line_width_multiplier);
         if wrapped.len() as i32 <= max_line_count {
-            return Some(add_size_tag(&wrapped.join("\n"), font_size.round() as i32));
+            let new_size = font_size.round() as i32;
+            let new_text = wrapped.join("\n");
+            return Some(if new_size != base_font_size {
+                add_size_tag(&new_text, new_size)
+            } else {
+                new_text
+            });
         }
 
         let prev_max_line_count = max_line_count;

--- a/src/il2cpp/hook/umamusume/PartsRaceAnalyzeRaceEventListItem.rs
+++ b/src/il2cpp/hook/umamusume/PartsRaceAnalyzeRaceEventListItem.rs
@@ -1,0 +1,30 @@
+use crate::il2cpp::{
+    hook::umamusume::PartsSingleModeSkillListItem,
+    symbols::{get_field_from_name, get_field_object_value, get_method_addr},
+    types::*,
+};
+
+static mut SKILL_ITEM_FIELD: *mut FieldInfo = 0 as _;
+pub fn get_skill_item(this: *mut Il2CppObject) -> *mut Il2CppObject {
+    get_field_object_value(this, unsafe { SKILL_ITEM_FIELD })
+}
+
+type SetupFn = extern "C" fn(this: *mut Il2CppObject, list_item_model: *mut Il2CppObject);
+fn Setup(this: *mut Il2CppObject, list_item_model: *mut Il2CppObject) {
+    get_orig_fn!(Setup, SetupFn)(this, list_item_model);
+    let skill_item = get_skill_item(this);
+    if !skill_item.is_null() {
+        PartsSingleModeSkillListItem::set_skill_name_text(skill_item);
+    }
+}
+
+pub fn init(umamusume: *const Il2CppImage) {
+    get_class_or_return!(umamusume, Gallop, PartsRaceAnalyzeRaceEventListItem);
+
+    let setup_addr = get_method_addr(PartsRaceAnalyzeRaceEventListItem, c"Setup", 1);
+    new_hook!(setup_addr, Setup);
+
+    unsafe {
+        SKILL_ITEM_FIELD = get_field_from_name(PartsRaceAnalyzeRaceEventListItem, c"_skillItem");
+    }
+}

--- a/src/il2cpp/hook/umamusume/PartsSingleModeSkillListItem.rs
+++ b/src/il2cpp/hook/umamusume/PartsSingleModeSkillListItem.rs
@@ -23,6 +23,8 @@ static mut _BGBUTTON_FIELD: *mut FieldInfo = 0 as _;
 pub fn get__bgButton(this: *mut Il2CppObject) -> *mut Il2CppObject {
     get_field_object_value(this, unsafe { _BGBUTTON_FIELD })
 }
+static mut set_skill_name_text_addr: usize = 0;
+impl_addr_wrapper_fn!(set_skill_name_text, set_skill_name_text_addr, (), this: *mut Il2CppObject);
 
 // PartsSingleModeSkillListItem.Info
 static mut get_IsDrawDesc_addr: usize = 0;
@@ -109,7 +111,7 @@ extern "C" fn UpdateItemOther(this: *mut Il2CppObject, skill_info: *mut Il2CppOb
     });
 }
 
-fn get_skill_text(skill_id: i32) -> (String, String) {    
+fn get_skill_text(skill_id: i32) -> (String, String) {
     let to_s = |opt_ptr: Option<*mut Il2CppString>| unsafe {
         opt_ptr.and_then(|p| p.as_ref()).map(|s| s.as_utf16str().to_string())
     };
@@ -190,6 +192,7 @@ pub fn init(umamusume: *const Il2CppImage) {
         NAMETEXT_FIELD = get_field_from_name(PartsSingleModeSkillListItem, c"_nameText");
         DESCTEXT_FIELD = get_field_from_name(PartsSingleModeSkillListItem, c"_descText");
         _BGBUTTON_FIELD = get_field_from_name(PartsSingleModeSkillListItem, c"_bgButton");
+        set_skill_name_text_addr = get_method_addr(PartsSingleModeSkillListItem, c"SetSkillNameText", 0);
 
         // PartsSingleModeSkillListItem.Info
         get_IsDrawDesc_addr = get_method_addr(Info, c"get_IsDrawDesc", 0);

--- a/src/il2cpp/hook/umamusume/mod.rs
+++ b/src/il2cpp/hook/umamusume/mod.rs
@@ -73,6 +73,7 @@ pub mod TweenAnimationTimelineSheetData;
 mod PartsSingleModeChoiceRewardTextElementViewModel;
 mod PartsCommonHeaderTitle;
 pub mod StoryParamChangeEffect;
+mod PartsRaceAnalyzeRaceEventListItem;
 
 pub fn init() {
     get_assembly_image_or_return!(image, "umamusume.dll");
@@ -151,4 +152,5 @@ pub fn init() {
     PartsSingleModeChoiceRewardTextElementViewModel::init(image);
     PartsCommonHeaderTitle::init(image);
     StoryParamChangeEffect::init(image);
+    PartsRaceAnalyzeRaceEventListItem::init(image);
 }


### PR DESCRIPTION
Not really a proper fix, but it makes the problem go away. Yay!

The problem (afaik): skill name text is truncated without tag awareness before setting it, removing the closing tag and most of the actual name.
One function does the right thing™ somehow. Magic.

Also skip size tags when not needed, which is a general improvement in case there are more cases like this one. But c6c277fe1adf4fa8d9de7314999a4c8557a3deff doesn't fix the race analysis problem on its own, as longer names would still get size-adjusted and then concatenated.