### PR TITLE
Bug fixes and improvements.

### DIFF
--- a/src/core/captions.rs
+++ b/src/core/captions.rs
@@ -10,7 +10,7 @@ use crate::{
             UnityEngine_CoreModule::{Component, GameObject, Object, Resources, Transform},
             UnityEngine_UI::Text,
             UnityEngine_UIModule::CanvasGroup,
-            umamusume::{AudioManager, GallopUtil, ImageCommon, MasterCharacterSystemText::{self, CharacterSystemText}, Notification, SceneManager, TextCommon, UIManager}
+            umamusume::{AudioManager, GallopUtil, ImageCommon, MasterCharacterSystemText::{self, CharacterSystemText}, Notification, PartsCharaMessageBase, SceneManager, TextCommon, UIManager}
         },
         symbols::{self, GCHandle, Thread},
         types::*
@@ -116,6 +116,35 @@ pub fn process_caption_request() {
         AudioManager::GetCueLength(am, final_data.cue_sheet.to_il2cpp_string(), final_data.cue_id)
     } else { 0.0 };
     let length = if length <= 0.0 { 3.0 } else { length };
+
+    let mut caption_is_redundant = false;
+    unsafe {
+        let parts_type = PartsCharaMessageBase::type_object();
+        if !parts_type.is_null() {
+            let objects = Object::FindObjectsOfType(parts_type, false);
+            if !objects.this.is_null() && objects.len() > 0 {
+                for obj in objects.as_slice() {
+                    if !obj.is_null() && PartsCharaMessageBase::get_IsPlaying(*obj) {
+                        caption_is_redundant = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    if !caption_is_redundant {
+        let balloon = GameObject::Find(
+            "/Gallop.GameSystem/SystemManagerRoot/SystemSingleton/UIManager/GameCanvas/MainCanvas/EpisodeCharacterView(Clone)/ContentsRoot/PartsEpisodeList/MidArea/BalloonRoot".to_il2cpp_string()
+        );
+        if !balloon.is_null() {
+            caption_is_redundant = true;
+        }
+    }
+
+    if caption_is_redundant {
+        return;
+    }
 
     let localized_text = Hachimi::instance().localized_data.load()
         .character_system_text_dict

--- a/src/core/gui.rs
+++ b/src/core/gui.rs
@@ -1216,9 +1216,14 @@ impl Gui {
                                 ui.vertical(|ui| {
                                     ui.label(t!("config_editor.enable_smtc"));
                                 });
-                                if ui.checkbox(&mut self.config.windows.enable_smtc, "").changed() {
+                                let mut enable_smtc = hachimi.config.load().windows.enable_smtc;
+                                if ui.checkbox(&mut enable_smtc, "").changed() {
                                     use crate::windows::smtc;
-                                    if self.config.windows.enable_smtc {
+                                    let mut config = hachimi.config.load().as_ref().clone();
+                                    config.windows.enable_smtc = enable_smtc;
+                                    save_and_reload_config(config);
+                                    self.config.windows.enable_smtc = enable_smtc;
+                                    if enable_smtc {
                                         smtc::init(crate::windows::wnd_hook::get_target_hwnd());
                                     } else {
                                         smtc::unregister();

--- a/src/il2cpp/hook/UnityEngine_CoreModule/GameObject.rs
+++ b/src/il2cpp/hook/UnityEngine_CoreModule/GameObject.rs
@@ -71,6 +71,9 @@ impl_addr_wrapper_fn!(SetActive, SETACTIVE_ADDR, (), this: *mut Il2CppObject, va
 static mut GET_ACTIVESELF_ADDR: usize = 0;
 impl_addr_wrapper_fn!(get_activeSelf, GET_ACTIVESELF_ADDR, bool, this: *mut Il2CppObject);
 
+static mut FIND_ADDR: usize = 0;
+impl_addr_wrapper_fn!(Find, FIND_ADDR, *mut Il2CppObject, name: *mut Il2CppString);
+
 // public Transform get_transform() { }
 static mut GET_TRANSFORM_ADDR: usize = 0;
 impl_addr_wrapper_fn!(get_transform, GET_TRANSFORM_ADDR, *mut Il2CppObject, this: *mut Il2CppObject);
@@ -155,6 +158,7 @@ pub fn init(UnityEngine_CoreModule: *const Il2CppImage) {
     unsafe {
         CLASS = GameObject;
         TYPE_OBJECT = get_type_object_for_class(GameObject);
+        FIND_ADDR = get_method_addr(GameObject, c"Find", 1);
         ADDCOMPONENT_ADDR = get_method_addr(GameObject, c"AddComponent", 1);
         GETCOMPONENT_ADDR = get_method_addr(GameObject, c"GetComponent", 1);
         GETCOMPONENTINCHILDREN_ADDR = get_method_addr(GameObject, c"GetComponentInChildren", 2);

--- a/src/il2cpp/hook/umamusume/PartsCharaMessageBase.rs
+++ b/src/il2cpp/hook/umamusume/PartsCharaMessageBase.rs
@@ -1,0 +1,27 @@
+use crate::il2cpp::{
+    symbols::{get_method_addr, get_type_object_for_class},
+    types::*
+};
+
+static mut CLASS: *mut Il2CppClass = 0 as _;
+pub fn class() -> *mut Il2CppClass {
+    unsafe { CLASS }
+}
+
+static mut TYPE_OBJECT: *mut Il2CppObject = 0 as _;
+pub fn type_object() -> *mut Il2CppObject {
+    unsafe { TYPE_OBJECT }
+}
+
+static mut GET_ISPLAYING_ADDR: usize = 0;
+impl_addr_wrapper_fn!(get_IsPlaying, GET_ISPLAYING_ADDR, bool, this: *mut Il2CppObject);
+
+pub fn init(umamusume: *const Il2CppImage) {
+    get_class_or_return!(umamusume, Gallop, PartsCharaMessageBase);
+
+    unsafe {
+        CLASS = PartsCharaMessageBase;
+        TYPE_OBJECT = get_type_object_for_class(PartsCharaMessageBase);
+        GET_ISPLAYING_ADDR = get_method_addr(PartsCharaMessageBase, c"get_IsPlaying", 0);
+    }
+}

--- a/src/il2cpp/hook/umamusume/PartsNickNameListItem.rs
+++ b/src/il2cpp/hook/umamusume/PartsNickNameListItem.rs
@@ -1,7 +1,10 @@
-use crate::il2cpp::{
-    hook::umamusume::PartsNickNameRibbon,
-    symbols::{get_field_from_name, get_field_object_value, get_method_addr},
-    types::*,
+use crate::{
+    core::{game::Region, Hachimi},
+    il2cpp::{
+        hook::umamusume::PartsNickNameRibbon,
+        symbols::{get_field_from_name, get_field_object_value, get_method_addr},
+        types::*,
+    },
 };
 
 static mut RIBBON_FIELD: *mut FieldInfo = 0 as _;
@@ -17,6 +20,10 @@ extern "C" fn Setup(this: *mut Il2CppObject, nickNameId: i32, onSelect: *mut Il2
 }
 
 pub fn init(umamusume: *const Il2CppImage) {
+    if Hachimi::instance().game.region != Region::Japan {
+        return;
+    }
+
     get_class_or_return!(umamusume, Gallop, PartsNickNameListItem);
 
     let initialize_addr = get_method_addr(PartsNickNameListItem, c"Setup", 2);

--- a/src/il2cpp/hook/umamusume/mod.rs
+++ b/src/il2cpp/hook/umamusume/mod.rs
@@ -63,6 +63,7 @@ pub mod Notification;
 pub mod TimeUtil;
 pub mod CameraData;
 pub mod DialogManager;
+pub mod PartsCharaMessageBase;
 
 pub mod SceneManager;
 
@@ -170,6 +171,7 @@ pub fn init() {
     Notification::init(image);
     TimeUtil::init(image);
     DialogManager::init(image);
+    PartsCharaMessageBase::init(image);
 
     SceneManager::init(image);
 

--- a/src/il2cpp/hook/umamusume/mod.rs
+++ b/src/il2cpp/hook/umamusume/mod.rs
@@ -84,9 +84,13 @@ mod StoryChoiceButton;
 mod DialogMissionListItem;
 mod PartsNamePlateBase;
 mod PartsSupportCardImproveDetail;
+#[cfg(target_os = "windows")]
 mod Connecting;
+#[cfg(target_os = "windows")]
 mod DownloadManager;
+#[cfg(target_os = "windows")]
 mod DownloadView;
+#[cfg(target_os = "windows")]
 mod DownloadErrorProcessor;
 mod TitleViewController;
 pub mod Director;
@@ -178,6 +182,10 @@ pub fn init() {
     #[cfg(target_os = "windows")]
     {
         PaymentUtility::init(image);
+        Connecting::init(image);
+        DownloadManager::init(image);
+        DownloadView::init(image);
+        DownloadErrorProcessor::init(image);
     }
     LowResolutionCamera::init(image);
     CameraData::init(image);
@@ -195,10 +203,6 @@ pub fn init() {
     DialogMissionListItem::init(image);
     PartsNamePlateBase::init(image);
     PartsSupportCardImproveDetail::init(image);
-    Connecting::init(image);
-    DownloadManager::init(image);
-    DownloadView::init(image);
-    DownloadErrorProcessor::init(image);
     TitleViewController::init(image);
     Director::init(image);
     CySpringNative::init(image);

--- a/src/windows/gui_impl/render_hook.rs
+++ b/src/windows/gui_impl/render_hook.rs
@@ -6,7 +6,7 @@ use windows::{
     core::{HRESULT, Interface, w},
     Win32::{
         Foundation::{HINSTANCE, HMODULE, HWND, LPARAM, LRESULT, RECT, WPARAM}, Graphics::{
-            Direct3D::{D3D_DRIVER_TYPE_HARDWARE, D3D_FEATURE_LEVEL, D3D_FEATURE_LEVEL_11_0},
+            Direct3D::{D3D_DRIVER_TYPE_HARDWARE, D3D_FEATURE_LEVEL, D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_11_0},
             Direct3D11::{D3D11CreateDeviceAndSwapChain, ID3D11Device, D3D11_CREATE_DEVICE_FLAG, D3D11_SDK_VERSION},
             Dxgi::{
                 Common::{DXGI_FORMAT, DXGI_FORMAT_R8G8B8A8_UNORM},
@@ -263,7 +263,7 @@ fn get_swap_chain_vtable() -> Result<*mut usize, Error> {
 
     unsafe {
         D3D11CreateDeviceAndSwapChain(
-            None, D3D_DRIVER_TYPE_HARDWARE, HMODULE::default(), D3D11_CREATE_DEVICE_FLAG(0), Some(&[D3D_FEATURE_LEVEL_11_0]),
+            None, D3D_DRIVER_TYPE_HARDWARE, HMODULE::default(), D3D11_CREATE_DEVICE_FLAG(0), Some(&[D3D_FEATURE_LEVEL_10_0, D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_11_0,]),
             D3D11_SDK_VERSION, Some(&swap_chain_desc), Some(&mut p_swap_chain), Some(&mut p_device),
             Some(&mut feature_level), None
         )

--- a/src/windows/smtc.rs
+++ b/src/windows/smtc.rs
@@ -322,11 +322,12 @@ fn update_metadata(smtc: &SystemMediaTransportControls, music_id: i32) {
     if music_id == 0 { return; }
 
     unsafe {
-        if CURRENT_MUSIC_ID != music_id {
-            if let Ok(updater) = smtc.DisplayUpdater() {
-                let _ = updater.SetThumbnail(None);
-                let _ = updater.Update();
-            }
+        if CURRENT_MUSIC_ID == music_id {
+            return;
+        }
+        if let Ok(updater) = smtc.DisplayUpdater() {
+            let _ = updater.SetThumbnail(None);
+            let _ = updater.Update();
         }
         CURRENT_MUSIC_ID = music_id;
     }
@@ -559,6 +560,11 @@ pub fn unregister() {
     let mut smtc_guard = SMTC_INSTANCE.lock().unwrap();
     if let Some(smtc) = smtc_guard.take() {
         let _ = smtc.SetIsEnabled(false);
+        unsafe {
+            CURRENT_MUSIC_ID = -1;
+            CURRENT_SCENE_HANDLE = -1;
+            LAST_STATUS = MediaPlaybackStatus::Closed;
+        }
         info!("SMTC unregistered");
     }
 }


### PR DESCRIPTION
- Fast path in SMTC module to prevent repeat SQL queries, fixes #94.
- The visibility of the SMTC display through the checkbox is now as expected.
- Restore hardware support removed by 5f967b0.
- Add region check to `PartsNickNameListItem` hook, fixes #92.
- Stricter logic in determining if a caption should be shown.
- Conditional compilation of hooks used for the taskbar progress indicator, as the taskbar module is already Windows-specific.
  - On Android, these hooks would interact with memory in a way where the game's tutorial would trigger a crash.