### PR TITLE
Global: Fix live_playback_loop crash and live slider not appearing while paused

### DIFF
--- a/src/il2cpp/hook/umamusume/Director/mod.rs
+++ b/src/il2cpp/hook/umamusume/Director/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{gui::IS_LIVE_SCENE, Hachimi},
+    core::{game::Region, gui::IS_LIVE_SCENE, Hachimi},
     il2cpp::{
         ext::StringExt,
         hook::UnityEngine_CoreModule::Camera,
@@ -554,7 +554,12 @@ pub fn init(umamusume: *const Il2CppImage) {
     let awake_addr = get_method_addr(Director, c"Awake", 0);
     new_hook!(awake_addr, Awake);
 
-    let pause_live_addr = get_method_addr(Director, c"PauseLive", 1);
+    let pause_live_addr = if Hachimi::instance().game.region == Region::Global {
+        get_method_addr(Director, c"PauseModel", 1)
+    } else {
+        get_method_addr(Director, c"PauseLive", 1)
+    };
+    
     new_hook!(pause_live_addr, PauseLive);
 
     #[cfg(target_os = "android")]


### PR DESCRIPTION
Fixes #118 
```text
2026-08-04T23:40:45.6654648Z [WARN] hachimi::il2cpp::symbols: get_method_addr: PauseLive = NULL
2026-08-04T23:40:45.6655507Z [INFO] hachimi::il2cpp::hook::umamusume::Director: new_hook!: PauseLive
2026-08-04T23:40:45.6656439Z [ERROR] hachimi::il2cpp::hook::umamusume::Director: pause_live_addr is null
...
2026-08-04T23:43:55.415331Z [WARN] hachimi::core::interceptor: Attempted to get invalid hook: 123145008324864
```
[hachimi.log](https://github.com/user-attachments/files/30724815/hachimi.log)


On Global, the `Director` class lacks a `PauseLive()` method, preventing the slider showing when concerts are paused, and is likely what causes live_playback_loop to crash.
_Haven't verified with a debugger, but the game no longer crashes when looping concerts :)_

Instead, it looks like we can use the `PauseModel()` method in Global, which seems to give us the same functionality.

I don't know if this is the correct fix so it will need more testing, but for me it works in Concert Theater, career winning lives, and the story concerts.
Hooking `PauseModel()` also still works in JP 2.29.0, so it should hopefully survive future global client updates, at least until it `PauseLive()` is added.


https://streamable.com/kbhv4b

https://github.com/user-attachments/assets/72ba650f-19e0-4e08-89e3-4450cdc98784


