### PR TITLE
build: update Installer revision hash in workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Build Installer
         run: |
-          git clone --depth 1 --revision b236ce341477890be1ee759bed8fd27c45862d7f https://github.com/teiosteppa/Installer
+          git clone --depth 1 --revision 0387eb987aa9bc446415844e321125dff16e210f https://github.com/teiosteppa/Installer
           copy build\hachimi.dll Installer
           move Cellar\build\cellar.dll Installer
           move FunnyHoney\FunnyHoney.exe Installer


### PR DESCRIPTION
Update to installer v3.2.3 includes komoegame support. Accomplished by searching for the registry key `HKEY_CURRENT_USER\Software\komoemumamusume` and using the value of `GameInstallPath`.