### PR TITLE
Fix race jikkyo commentary not being translated on Global

### DIFF
--- a/src/il2cpp/hook/umamusume/RaceJikkyo.rs
+++ b/src/il2cpp/hook/umamusume/RaceJikkyo.rs
@@ -46,9 +46,15 @@ fn init_message(umamusume: *const Il2CppImage) {
         return;
     };
 
+    let id_field = get_field_from_name(class, c"Id");
+    let text_field = get_field_from_name(class, c"Message");
+    if id_field.is_null() || text_field.is_null() {
+        return;
+    }
+
     unsafe {
-        MESSAGE_ID_FIELD = get_field_from_name(class, c"Id");
-        MESSAGE_TEXT_FIELD = get_field_from_name(class, c"Message");
+        MESSAGE_ID_FIELD = id_field;
+        MESSAGE_TEXT_FIELD = text_field;
     }
 
     let cache_addr = get_method_addr(class, c"Cache", 1);
@@ -63,9 +69,15 @@ fn init_comment(umamusume: *const Il2CppImage) {
         return;
     };
 
+    let id_field = get_field_from_name(class, c"Id");
+    let text_field = get_field_from_name(class, c"Message");
+    if id_field.is_null() || text_field.is_null() {
+        return;
+    }
+
     unsafe {
-        COMMENT_ID_FIELD = get_field_from_name(class, c"Id");
-        COMMENT_TEXT_FIELD = get_field_from_name(class, c"Message");
+        COMMENT_ID_FIELD = id_field;
+        COMMENT_TEXT_FIELD = text_field;
     }
 
     let cache_addr = get_method_addr(class, c"Cache", 1);

--- a/src/il2cpp/hook/umamusume/RaceJikkyo.rs
+++ b/src/il2cpp/hook/umamusume/RaceJikkyo.rs
@@ -1,0 +1,78 @@
+use crate::{
+    core::Hachimi,
+    il2cpp::{
+        ext::StringExt,
+        symbols::{find_nested_class, get_class, get_field_from_name, get_field_value, get_method_addr, set_field_object_value},
+        types::*,
+    },
+};
+
+static mut MESSAGE_ID_FIELD: *mut FieldInfo = std::ptr::null_mut();
+static mut MESSAGE_TEXT_FIELD: *mut FieldInfo = std::ptr::null_mut();
+static mut COMMENT_ID_FIELD: *mut FieldInfo = std::ptr::null_mut();
+static mut COMMENT_TEXT_FIELD: *mut FieldInfo = std::ptr::null_mut();
+
+type CacheFn = extern "C" fn(this: *mut Il2CppObject, tag_list: *mut Il2CppArray);
+
+extern "C" fn CacheMessage(this: *mut Il2CppObject, tag_list: *mut Il2CppArray) {
+    let id: i32 = get_field_value(this, unsafe { MESSAGE_ID_FIELD });
+    let localized_data = Hachimi::instance().localized_data.load();
+
+    if let Some(text) = localized_data.race_jikkyo_message_dict.get(&id) {
+        let text = text.to_il2cpp_string();
+        set_field_object_value(this, unsafe { MESSAGE_TEXT_FIELD }, text);
+    }
+
+    get_orig_fn!(CacheMessage, CacheFn)(this, tag_list);
+}
+
+extern "C" fn CacheComment(this: *mut Il2CppObject, tag_list: *mut Il2CppArray) {
+    let id: i32 = get_field_value(this, unsafe { COMMENT_ID_FIELD });
+    let localized_data = Hachimi::instance().localized_data.load();
+
+    if let Some(text) = localized_data.race_jikkyo_comment_dict.get(&id) {
+        let text = text.to_il2cpp_string();
+        set_field_object_value(this, unsafe { COMMENT_TEXT_FIELD }, text);
+    }
+
+    get_orig_fn!(CacheComment, CacheFn)(this, tag_list);
+}
+
+fn init_message(umamusume: *const Il2CppImage) {
+    let Ok(parent) = get_class(umamusume, c"Gallop", c"MasterRaceJikkyoMessage") else {
+        return;
+    };
+    let Ok(class) = find_nested_class(parent, c"RaceJikkyoMessage") else {
+        return;
+    };
+
+    unsafe {
+        MESSAGE_ID_FIELD = get_field_from_name(class, c"Id");
+        MESSAGE_TEXT_FIELD = get_field_from_name(class, c"Message");
+    }
+
+    let cache_addr = get_method_addr(class, c"Cache", 1);
+    new_hook!(cache_addr, CacheMessage);
+}
+
+fn init_comment(umamusume: *const Il2CppImage) {
+    let Ok(parent) = get_class(umamusume, c"Gallop", c"MasterRaceJikkyoComment") else {
+        return;
+    };
+    let Ok(class) = find_nested_class(parent, c"RaceJikkyoComment") else {
+        return;
+    };
+
+    unsafe {
+        COMMENT_ID_FIELD = get_field_from_name(class, c"Id");
+        COMMENT_TEXT_FIELD = get_field_from_name(class, c"Message");
+    }
+
+    let cache_addr = get_method_addr(class, c"Cache", 1);
+    new_hook!(cache_addr, CacheComment);
+}
+
+pub fn init(umamusume: *const Il2CppImage) {
+    init_message(umamusume);
+    init_comment(umamusume);
+}

--- a/src/il2cpp/hook/umamusume/mod.rs
+++ b/src/il2cpp/hook/umamusume/mod.rs
@@ -26,6 +26,7 @@ pub mod StoryViewTextControllerBase;
 mod StoryViewTextControllerLandscape;
 mod StoryViewTextControllerSingleMode;
 mod JikkyoDisplay;
+mod RaceJikkyo;
 pub mod Screen;
 #[cfg(target_os = "windows")]
 pub mod StandaloneWindowResize;
@@ -189,6 +190,7 @@ pub fn init() {
     StoryViewTextControllerLandscape::init(image);
     StoryViewTextControllerSingleMode::init(image);
     JikkyoDisplay::init(image);
+    RaceJikkyo::init(image);
     Screen::init(image);
     TrainingParamChangePlate::init(image);
     SingleModeUtils::init(image);

--- a/src/il2cpp/sql.rs
+++ b/src/il2cpp/sql.rs
@@ -353,8 +353,10 @@ impl SelectQueryState for CharacterSystemTextQuery {
 // race_jikkyo_comment
 #[derive(Default)]
 pub struct RaceJikkyoCommentQuery {
-    // SELECT
+    // may appear in both
     id: Column,
+
+    // SELECT
     message: Column
 }
 
@@ -367,16 +369,22 @@ impl SelectQueryState for RaceJikkyoCommentQuery {
         }
     }
 
-    fn add_param(&mut self, _idx: i32, _name: &str) {}
+    fn add_param(&mut self, idx: i32, name: &str) {
+        if name == "id" {
+            self.id.param_idx = Some(idx);
+        }
+    }
 
-    fn bind_int(&mut self, _idx: i32, _value: i32) {}
+    fn bind_int(&mut self, idx: i32, value: i32) {
+        self.id.try_bind_int(idx, value);
+    }
 
     fn get_text(&self, query: *mut Il2CppObject, idx: i32) -> Option<*mut Il2CppString> {
         if !self.message.is_select_idx(idx) {
             return None;
         }
 
-        if let Some(id) = self.id.try_get_int(query) {
+        if let Some(id) = self.id.value_or_try_get_int(query) {
             return Hachimi::instance().localized_data.load()
                 .race_jikkyo_comment_dict
                 .get(&id)
@@ -390,8 +398,10 @@ impl SelectQueryState for RaceJikkyoCommentQuery {
 // race_jikkyo_message
 #[derive(Default)]
 pub struct RaceJikkyoMessageQuery {
-    // SELECT
+    // may appear in both
     id: Column,
+
+    // SELECT
     message: Column
 }
 
@@ -404,16 +414,22 @@ impl SelectQueryState for RaceJikkyoMessageQuery {
         }
     }
 
-    fn add_param(&mut self, _idx: i32, _name: &str) {}
+    fn add_param(&mut self, idx: i32, name: &str) {
+        if name == "id" {
+            self.id.param_idx = Some(idx);
+        }
+    }
 
-    fn bind_int(&mut self, _idx: i32, _value: i32) {}
+    fn bind_int(&mut self, idx: i32, value: i32) {
+        self.id.try_bind_int(idx, value);
+    }
 
     fn get_text(&self, query: *mut Il2CppObject, idx: i32) -> Option<*mut Il2CppString> {
         if !self.message.is_select_idx(idx) {
             return None;
         }
 
-        if let Some(id) = self.id.try_get_int(query) {
+        if let Some(id) = self.id.value_or_try_get_int(query) {
             return Hachimi::instance().localized_data.load()
                 .race_jikkyo_message_dict
                 .get(&id)


### PR DESCRIPTION
Global stopped selecting race_jikkyo.id in its queries, so Hachimi lost the id association for the translation. Support the id bound as a SQL param, and replace Message before Cache() since the game rebuilds the final text from messageStr.