### PR TITLE
Fix race jikkyo translation on Global

### DIFF
--- a/src/il2cpp/hook/umamusume/RaceJikkyo.rs
+++ b/src/il2cpp/hook/umamusume/RaceJikkyo.rs
@@ -1,0 +1,82 @@
+use crate::{
+    core::Hachimi,
+    il2cpp::{
+        ext::StringExt,
+        symbols::{get_field_from_name, get_field_value, get_method_addr, set_field_object_value},
+        types::*,
+    },
+};
+
+static mut MESSAGE_ID_FIELD: *mut FieldInfo = std::ptr::null_mut();
+static mut MESSAGE_TEXT_FIELD: *mut FieldInfo = std::ptr::null_mut();
+static mut COMMENT_ID_FIELD: *mut FieldInfo = std::ptr::null_mut();
+static mut COMMENT_TEXT_FIELD: *mut FieldInfo = std::ptr::null_mut();
+
+type CacheFn = extern "C" fn(this: *mut Il2CppObject, tag_list: *mut Il2CppArray);
+
+extern "C" fn CacheMessage(this: *mut Il2CppObject, tag_list: *mut Il2CppArray) {
+    let id: i32 = get_field_value(this, unsafe { MESSAGE_ID_FIELD });
+    let localized_data = Hachimi::instance().localized_data.load();
+
+    if let Some(text) = localized_data.race_jikkyo_message_dict.get(&id) {
+        let text = text.to_il2cpp_string();
+        set_field_object_value(this, unsafe { MESSAGE_TEXT_FIELD }, text);
+    }
+
+    get_orig_fn!(CacheMessage, CacheFn)(this, tag_list);
+}
+
+extern "C" fn CacheComment(this: *mut Il2CppObject, tag_list: *mut Il2CppArray) {
+    let id: i32 = get_field_value(this, unsafe { COMMENT_ID_FIELD });
+    let localized_data = Hachimi::instance().localized_data.load();
+
+    if let Some(text) = localized_data.race_jikkyo_comment_dict.get(&id) {
+        let text = text.to_il2cpp_string();
+        set_field_object_value(this, unsafe { COMMENT_TEXT_FIELD }, text);
+    }
+
+    get_orig_fn!(CacheComment, CacheFn)(this, tag_list);
+}
+
+fn init_message(umamusume: *const Il2CppImage) {
+    get_class_or_return!(umamusume, Gallop, MasterRaceJikkyoMessage);
+    find_nested_class_or_return!(MasterRaceJikkyoMessage, RaceJikkyoMessage);
+
+    let id_field = get_field_from_name(RaceJikkyoMessage, c"Id");
+    let text_field = get_field_from_name(RaceJikkyoMessage, c"Message");
+    if id_field.is_null() || text_field.is_null() {
+        return;
+    }
+
+    unsafe {
+        MESSAGE_ID_FIELD = id_field;
+        MESSAGE_TEXT_FIELD = text_field;
+    }
+
+    let cache_addr = get_method_addr(RaceJikkyoMessage, c"Cache", 1);
+    new_hook!(cache_addr, CacheMessage);
+}
+
+fn init_comment(umamusume: *const Il2CppImage) {
+    get_class_or_return!(umamusume, Gallop, MasterRaceJikkyoComment);
+    find_nested_class_or_return!(MasterRaceJikkyoComment, RaceJikkyoComment);
+
+    let id_field = get_field_from_name(RaceJikkyoComment, c"Id");
+    let text_field = get_field_from_name(RaceJikkyoComment, c"Message");
+    if id_field.is_null() || text_field.is_null() {
+        return;
+    }
+
+    unsafe {
+        COMMENT_ID_FIELD = id_field;
+        COMMENT_TEXT_FIELD = text_field;
+    }
+
+    let cache_addr = get_method_addr(RaceJikkyoComment, c"Cache", 1);
+    new_hook!(cache_addr, CacheComment);
+}
+
+pub fn init(umamusume: *const Il2CppImage) {
+    init_message(umamusume);
+    init_comment(umamusume);
+}

--- a/src/il2cpp/hook/umamusume/mod.rs
+++ b/src/il2cpp/hook/umamusume/mod.rs
@@ -26,6 +26,7 @@ pub mod StoryViewTextControllerBase;
 mod StoryViewTextControllerLandscape;
 mod StoryViewTextControllerSingleMode;
 mod JikkyoDisplay;
+mod RaceJikkyo;
 pub mod Screen;
 #[cfg(target_os = "windows")]
 pub mod StandaloneWindowResize;
@@ -189,6 +190,7 @@ pub fn init() {
     StoryViewTextControllerLandscape::init(image);
     StoryViewTextControllerSingleMode::init(image);
     JikkyoDisplay::init(image);
+    RaceJikkyo::init(image);
     Screen::init(image);
     TrainingParamChangePlate::init(image);
     SingleModeUtils::init(image);


### PR DESCRIPTION
On Global the race jikkyo commentary stays untranslated even though the
SQL layer translates the race_jikkyo_message / race_jikkyo_comment
columns. The final text shown during a race is rebuilt in
RaceJikkyoMessage.Cache() / RaceJikkyoComment.Cache() from the row's
Message field after tag processing, so the SQL-layer result never
reaches the display.

This hooks Cache to replace Message with the localized text before the
original method runs, so messageStr is built from the translated text.
The hook is only installed when both the Id and Message fields resolve;
otherwise it is skipped, so the change is inert on builds where the
classes or fields are unavailable.

Verified in a live race on Global (from hachimi.log):
- 2869/2869 message ids and 296/296 comment ids from the localization
  dictionaries were applied (100% coverage)
- no errors in the log during the race

Checks: clippy -- -D warnings on x86_64-pc-windows-msvc and
aarch64-linux-android, cargo check, cargo test, and rustfmt on the new
file all pass.