### PR TITLE
Fix crash when entering the 5.5th Anniversary Live "Beyond"

### DIFF
--- a/src/il2cpp/hook/umamusume/AssetManager.rs
+++ b/src/il2cpp/hook/umamusume/AssetManager.rs
@@ -1,5 +1,5 @@
 use crate::il2cpp::{
-    symbols::{get_method_addr, get_assembly_image, get_class},
+    symbols::{get_method_addr, get_assembly_image, get_class, invoke_object_method},
     types::*
 };
 
@@ -11,8 +11,10 @@ pub fn class() -> *mut Il2CppClass {
 static mut GET_LOADER_ADDR: usize = 0;
 impl_addr_wrapper_fn!(get_Loader, GET_LOADER_ADDR, *mut Il2CppObject,);
 
-static mut LOADASSETHANDLE_ADDR: usize = 0;
-impl_addr_wrapper_fn!(LoadAssetHandle, LOADASSETHANDLE_ADDR, *mut Il2CppObject, this: *mut Il2CppObject, path: *mut Il2CppString, flag: bool);
+pub fn LoadAssetHandle(this: *mut Il2CppObject, path: *mut Il2CppString, flag: bool) -> *mut Il2CppObject {
+    let mut params: [*mut std::ffi::c_void; 2] = [path as *mut _, &flag as *const _ as *mut _];
+    invoke_object_method(this, c"LoadAssetHandle", 2, &mut params).unwrap_or(std::ptr::null_mut())
+}
 
 static mut GET_ASSETBUNDLE_ADDR: usize = 0;
 impl_addr_wrapper_fn!(get_assetBundle, GET_ASSETBUNDLE_ADDR, *mut Il2CppObject, this: *mut Il2CppObject);
@@ -26,14 +28,6 @@ pub fn init(umamusume: *const Il2CppImage) {
     }
 
     if let Ok(cyan_image) = get_assembly_image(c"_Cyan.dll") {
-        if let Ok(loader_class) = get_class(cyan_image, c"Cyan.Loader", c"AssetLoader") {
-            unsafe {
-                LOADASSETHANDLE_ADDR = get_method_addr(loader_class, c"LoadAssetHandle", 2);
-            }
-        } else {
-            error!("Failed to find AssetLoader class in _Cyan.dll");
-        }
-
         if let Ok(asset_handle_class) = get_class(cyan_image, c"Cyan.Loader", c"AssetHandle") {
             unsafe {
                 GET_ASSETBUNDLE_ADDR = get_method_addr(asset_handle_class, c"get_assetBundle", 0);


### PR DESCRIPTION
<!--
Don't submit a Pull Request with copy-pasted, untested code generated by ChatGPT, Copilot, or other AI tools.

There has been a couple of PRs lately dumped on the project that don't work properly, mess up the formatting, or have to be completely rewritten. As a project maintainer, I don't have the time to fix code you didn't write or test yourself.

AI code has no clear copyright protection under US law and often copies code from other projects without credit, which causes licensing problems for this repo.

Using AI tools to help debug, look up syntax, or assist with formatting is fine, provided that:
- **You understand the code:** You must be able to explain how your changes work and address feedback during review.
- **You tested it locally:** The code builds, runs, adheres to the project's style, and doesn't introduce regressions.
- **No uncredited code:** The output does not pull copyrighted code from other projects without proper licensing and attribution.

If a PR violates any of these policies, it will be ghosted.
-->
Confirmed that “Beyond” no longer crashes in either the story or Live Theater. It works correctly on Windows. Android has not been tested, but the fix is small and should not cause any issues.