### PR TITLE
fix: access violation crash in asynchronous Sugoi translation client

### DIFF
--- a/src/core/sugoi_client.rs
+++ b/src/core/sugoi_client.rs
@@ -4,12 +4,24 @@ use fnv::{FnvHashMap, FnvHashSet};
 use once_cell::sync::Lazy;
 use serde::Serialize;
 
+use crate::il2cpp::{symbols::GCHandle,types::Il2CppString};
+
 use super::{Error, Hachimi};
 
 pub struct SugoiClient {
     agent: ureq::Agent,
     url: String,
     request_lock: Mutex<()>,
+}
+
+pub struct SugoiString {
+    pub str_handle: GCHandle,
+    pub str: String
+}
+impl SugoiString {
+    pub fn original(&self) -> *mut Il2CppString {
+        self.str_handle.target() as _
+    }
 }
 
 static INSTANCE: Lazy<Arc<SugoiClient>> = Lazy::new(|| {

--- a/src/core/sugoi_client.rs
+++ b/src/core/sugoi_client.rs
@@ -14,12 +14,12 @@ pub struct SugoiClient {
     request_lock: Mutex<()>,
 }
 
-pub struct SugoiString {
+pub struct StringInfo {
     pub str_handle: GCHandle,
     pub str: String
 }
-impl SugoiString {
-    pub fn original(&self) -> *mut Il2CppString {
+impl StringInfo {
+    pub fn object(&self) -> *mut Il2CppString {
         self.str_handle.target() as _
     }
 }

--- a/src/il2cpp/hook/UnityEngine_TextRenderingModule/TextMesh.rs
+++ b/src/il2cpp/hook/UnityEngine_TextRenderingModule/TextMesh.rs
@@ -1,10 +1,10 @@
 use std::sync::Mutex;
 use fnv::FnvHashMap;
 use once_cell::sync::Lazy;
-use crate::core::sugoi_client::SugoiClient;
-use crate::il2cpp::{ext::{Il2CppStringExt, StringExt}, hook::UnityEngine_CoreModule::Object, symbols::get_method_addr, types::*};
+use crate::core::sugoi_client::{SugoiClient, SugoiString};
+use crate::il2cpp::{ext::{Il2CppStringExt, StringExt}, symbols::{get_method_addr, GCHandle}, types::*};
 
-pub static ACTIVE_TEXT_MESH_COMPONENTS: Lazy<Mutex<FnvHashMap<usize, String>>> = Lazy::new(|| {
+pub static ACTIVE_TEXT_MESH_COMPONENTS: Lazy<Mutex<FnvHashMap<usize, SugoiString>>> = Lazy::new(|| {
     Mutex::new(FnvHashMap::default())
 });
 
@@ -20,8 +20,12 @@ pub extern "C" fn set_text_hook(this: *mut Il2CppObject, value: *mut Il2CppStrin
     }
 
     let orig_str = unsafe { (*value).as_utf16str().to_string() };
+    let str_info = SugoiString {
+        str_handle: GCHandle::new_weak_ref(this, false),
+        str: orig_str.clone()
+    };
 
-    ACTIVE_TEXT_MESH_COMPONENTS.lock().unwrap().insert(this as usize, orig_str.clone());
+    ACTIVE_TEXT_MESH_COMPONENTS.lock().unwrap().insert(this as usize, str_info);
 
     if let Some(trans) = SugoiClient::instance().get_cached(&orig_str) {
         return get_orig_fn!(set_text_hook, SetTextFn)(this, trans.to_il2cpp_string());
@@ -35,13 +39,13 @@ pub fn apply_translations(completed: &[(String, String)]) {
     {
         let mut tracker = ACTIVE_TEXT_MESH_COMPONENTS.lock().unwrap();
 
-        tracker.retain(|&ptr, _| Object::op_Implicit(ptr as *mut Il2CppObject));
+        tracker.retain(|_, info| !info.original().is_null());
 
         for (orig, trans) in completed {
             let unity_string = trans.to_il2cpp_string();
 
             for (&ptr, saved_orig) in tracker.iter() {
-                if saved_orig == orig {
+                if &saved_orig.str == orig {
                     updates_to_apply.push((ptr, unity_string));
                 }
             }
@@ -49,9 +53,7 @@ pub fn apply_translations(completed: &[(String, String)]) {
     }
 
     for (ptr, unity_string) in updates_to_apply {
-        if Object::op_Implicit(ptr as *mut Il2CppObject) {
-            get_orig_fn!(set_text_hook, SetTextFn)(ptr as *mut Il2CppObject, unity_string);
-        }
+        get_orig_fn!(set_text_hook, SetTextFn)(ptr as *mut Il2CppObject, unity_string);
     }
 }
 

--- a/src/il2cpp/hook/UnityEngine_TextRenderingModule/TextMesh.rs
+++ b/src/il2cpp/hook/UnityEngine_TextRenderingModule/TextMesh.rs
@@ -1,10 +1,10 @@
 use std::sync::Mutex;
 use fnv::FnvHashMap;
 use once_cell::sync::Lazy;
-use crate::core::sugoi_client::{SugoiClient, SugoiString};
+use crate::core::sugoi_client::{SugoiClient, StringInfo};
 use crate::il2cpp::{ext::{Il2CppStringExt, StringExt}, symbols::{get_method_addr, GCHandle}, types::*};
 
-pub static ACTIVE_TEXT_MESH_COMPONENTS: Lazy<Mutex<FnvHashMap<usize, SugoiString>>> = Lazy::new(|| {
+pub static ACTIVE_TEXT_MESH_COMPONENTS: Lazy<Mutex<FnvHashMap<usize, StringInfo>>> = Lazy::new(|| {
     Mutex::new(FnvHashMap::default())
 });
 
@@ -20,7 +20,7 @@ pub extern "C" fn set_text_hook(this: *mut Il2CppObject, value: *mut Il2CppStrin
     }
 
     let orig_str = unsafe { (*value).as_utf16str().to_string() };
-    let str_info = SugoiString {
+    let str_info = StringInfo {
         str_handle: GCHandle::new_weak_ref(this, false),
         str: orig_str.clone()
     };
@@ -39,7 +39,7 @@ pub fn apply_translations(completed: &[(String, String)]) {
     {
         let mut tracker = ACTIVE_TEXT_MESH_COMPONENTS.lock().unwrap();
 
-        tracker.retain(|_, info| !info.original().is_null());
+        tracker.retain(|_, info| !info.object().is_null());
 
         for (orig, trans) in completed {
             let unity_string = trans.to_il2cpp_string();

--- a/src/il2cpp/hook/UnityEngine_UI/Text.rs
+++ b/src/il2cpp/hook/UnityEngine_UI/Text.rs
@@ -1,8 +1,9 @@
 use std::sync::Mutex;
 use fnv::FnvHashMap;
 use once_cell::sync::Lazy;
-use crate::core::sugoi_client::SugoiClient;
-use crate::il2cpp::{ext::{Il2CppStringExt, StringExt}, hook::{UnityEngine_TextRenderingModule::TextAnchor, UnityEngine_CoreModule::Object}, symbols::get_method_addr, types::*};
+use crate::core::sugoi_client::{SugoiClient, SugoiString};
+use crate::il2cpp::symbols::GCHandle;
+use crate::il2cpp::{ext::{Il2CppStringExt, StringExt}, hook::UnityEngine_TextRenderingModule::TextAnchor, symbols::get_method_addr, types::*};
 
 static mut GET_LINESPACING_ADDR: usize = 0;
 impl_addr_wrapper_fn!(get_lineSpacing, GET_LINESPACING_ADDR, f32, this: *mut Il2CppObject);
@@ -62,7 +63,7 @@ pub fn set_best_fit_downscale(this: *mut Il2CppObject) {
     set_best_fit(this, true);
 }
 
-pub static ACTIVE_TEXT_COMPONENTS: Lazy<Mutex<FnvHashMap<usize, String>>> = Lazy::new(|| {
+pub static ACTIVE_TEXT_COMPONENTS: Lazy<Mutex<FnvHashMap<usize, SugoiString>>> = Lazy::new(|| {
     Mutex::new(FnvHashMap::default())
 });
 
@@ -78,8 +79,12 @@ pub extern "C" fn set_text_hook(this: *mut Il2CppObject, value: *mut Il2CppStrin
     }
 
     let orig_str = unsafe { (*value).as_utf16str().to_string() };
+    let str_info = SugoiString {
+        str_handle: GCHandle::new_weak_ref(this, false),
+        str: orig_str.clone()
+    };
 
-    ACTIVE_TEXT_COMPONENTS.lock().unwrap().insert(this as usize, orig_str.clone());
+    ACTIVE_TEXT_COMPONENTS.lock().unwrap().insert(this as usize, str_info);
 
     if let Some(trans) = SugoiClient::instance().get_cached(&orig_str) {
         return get_orig_fn!(set_text_hook, SetTextFn)(this, trans.to_il2cpp_string());
@@ -93,13 +98,13 @@ pub fn apply_translations(completed: &[(String, String)]) {
     {
         let mut tracker = ACTIVE_TEXT_COMPONENTS.lock().unwrap();
 
-        tracker.retain(|&ptr, _| Object::op_Implicit(ptr as *mut Il2CppObject));
+        tracker.retain(|_, info| !info.original().is_null());
 
         for (orig, trans) in completed {
             let unity_string = trans.to_il2cpp_string();
 
             for (&ptr, saved_orig) in tracker.iter() {
-                if saved_orig == orig {
+                if &saved_orig.str == orig {
                     updates_to_apply.push((ptr, unity_string));
                 }
             }
@@ -107,9 +112,7 @@ pub fn apply_translations(completed: &[(String, String)]) {
     }
 
     for (ptr, unity_string) in updates_to_apply {
-        if Object::op_Implicit(ptr as *mut Il2CppObject) {
-            get_orig_fn!(set_text_hook, SetTextFn)(ptr as *mut Il2CppObject, unity_string);
-        }
+        get_orig_fn!(set_text_hook, SetTextFn)(ptr as *mut Il2CppObject, unity_string);
     }
 }
 

--- a/src/il2cpp/hook/UnityEngine_UI/Text.rs
+++ b/src/il2cpp/hook/UnityEngine_UI/Text.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 use fnv::FnvHashMap;
 use once_cell::sync::Lazy;
-use crate::core::sugoi_client::{SugoiClient, SugoiString};
+use crate::core::sugoi_client::{SugoiClient, StringInfo};
 use crate::il2cpp::symbols::GCHandle;
 use crate::il2cpp::{ext::{Il2CppStringExt, StringExt}, hook::UnityEngine_TextRenderingModule::TextAnchor, symbols::get_method_addr, types::*};
 
@@ -63,7 +63,7 @@ pub fn set_best_fit_downscale(this: *mut Il2CppObject) {
     set_best_fit(this, true);
 }
 
-pub static ACTIVE_TEXT_COMPONENTS: Lazy<Mutex<FnvHashMap<usize, SugoiString>>> = Lazy::new(|| {
+pub static ACTIVE_TEXT_COMPONENTS: Lazy<Mutex<FnvHashMap<usize, StringInfo>>> = Lazy::new(|| {
     Mutex::new(FnvHashMap::default())
 });
 
@@ -79,7 +79,7 @@ pub extern "C" fn set_text_hook(this: *mut Il2CppObject, value: *mut Il2CppStrin
     }
 
     let orig_str = unsafe { (*value).as_utf16str().to_string() };
-    let str_info = SugoiString {
+    let str_info = StringInfo {
         str_handle: GCHandle::new_weak_ref(this, false),
         str: orig_str.clone()
     };
@@ -98,7 +98,7 @@ pub fn apply_translations(completed: &[(String, String)]) {
     {
         let mut tracker = ACTIVE_TEXT_COMPONENTS.lock().unwrap();
 
-        tracker.retain(|_, info| !info.original().is_null());
+        tracker.retain(|_, info| !info.object().is_null());
 
         for (orig, trans) in completed {
             let unity_string = trans.to_il2cpp_string();


### PR DESCRIPTION
A few users in the Discord reported that the machine translation client rewrite (introduced in v0.26.0) was causing game crashes. Crashes seemed to happen less often if the Sugoi API server was quicker to respond (e.g. using Offline translator instead of LLM) however it appeared to be inevitable from the moment auto translate was enabled.
Looking into the crash I found an EXC_ACCESS_VIOLATION on `System.Object::op_Implicit(Il2CppObject*)` which is called by us in [the UnityEngine.UI::Text apply_translations function](https://github.com/kairusds/Hachimi-Edge/blob/c6889bbea5450a8886a7ed2deb7299e1ebdf1a25/src/il2cpp/hook/UnityEngine_UI/Text.rs#L96).

Fixed by replacing the retention check in the tracker FnvHashMap: instead of trying to check if the raw pointers are alive, we create weak references to the managed strings, and let the IL2CPP garbage collector tell us their status in the lifecycle (if the target is null, the object has been GC'ed). This is also more conformant with [.NET interop best practices](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.gchandle?view=netframework-4.0).

Tested by @spoot._. and @arkhize in the Discord, along with myself; auto TL no longer causes this fatal error.