### PR TITLE
Add support for translating the values from "Skill data descriptions"…

### DIFF
--- a/src/core/hachimi.rs
+++ b/src/core/hachimi.rs
@@ -282,6 +282,13 @@ impl Hachimi {
         }
         
         self.localized_data.store(Arc::new(new_data));
+
+        if !self.skill_data_desc.load().descs.is_empty() {
+            let data = SkillDataDesc::load_from_db();
+            if !data.descs.is_empty() {
+                self.skill_data_desc.store(Arc::new(data));
+            }
+        }
     }
 
     pub fn init_character_data(&self) {
@@ -1027,6 +1034,7 @@ pub struct LocalizedData {
     pub character_system_text_dict: FnvHashMap<i32, FnvHashMap<i32, String>>, // {"character_id": {"voice_id": "text"}}
     pub race_jikkyo_comment_dict: FnvHashMap<i32, String>, // {"id": "text"}
     pub race_jikkyo_message_dict: FnvHashMap<i32, String>, // {"id": "text"}
+    pub skill_data_desc_dict: FnvHashMap<String, String>, // {"skill_data_desc.<key>": "text"}
     assets_path: Option<PathBuf>,
 
     pub plural_form: plurals::Resolver,
@@ -1086,6 +1094,7 @@ impl LocalizedData {
             character_system_text_dict: Self::load_dict_static(&path, config.character_system_text_dict.as_ref()).unwrap_or_default(),
             race_jikkyo_comment_dict: Self::load_dict_static(&path, config.race_jikkyo_comment_dict.as_ref()).unwrap_or_default(),
             race_jikkyo_message_dict: Self::load_dict_static(&path, config.race_jikkyo_message_dict.as_ref()).unwrap_or_default(),
+            skill_data_desc_dict: Self::load_dict_static_ex(&path, Some("skill_data_desc_dict.json"), true).unwrap_or_default(),
             assets_path: path.as_ref()
                 .map(|p| config.assets_dir.as_ref()
                     .map(|dir| p.join(dir))

--- a/src/il2cpp/sql.rs
+++ b/src/il2cpp/sql.rs
@@ -347,6 +347,10 @@ impl SkillDataDesc {
 
     fn str(key: &str) -> Option<String> {
         let full_key = format!("skill_data_desc.{key}");
+        let localized_data = Hachimi::instance().localized_data.load();
+        if let Some(text) = localized_data.skill_data_desc_dict.get(full_key.as_str()) {
+            return Some(text.to_string());
+        }
         let locale = locale();
         crate::_rust_i18n_try_translate(&locale, full_key.as_str()).map(|text| text.to_string())
     }


### PR DESCRIPTION
… via translation repos

- localized_data/skill_data_desc_dict.json

<!--
Don't submit a Pull Request with copy-pasted, untested code generated by ChatGPT, Copilot, or other AI tools.

There has been a couple of PRs lately dumped on the project that don't work properly, mess up the formatting, or have to be completely rewritten. As a project maintainer, I don't have the time to fix code you didn't write or test yourself.

AI code has no clear copyright protection under US law and often copies code from other projects without credit, which causes licensing problems for this repo.

Using AI tools to help debug, look up syntax, or assist with formatting is fine, provided that:
- **You understand the code:** You must be able to explain how your changes work and address feedback during review.
- **You tested it locally:** The code builds, runs, adheres to the project's style, and doesn't introduce regressions.
- **No uncredited code:** The output does not pull copyrighted code from other projects without proper licensing and attribution.

If a PR violates any of these policies, it will be ghosted.
-->