### PR TITLE
Fix skill_data_desc rebuild threading and text wrapping

### DIFF
--- a/src/core/hachimi.rs
+++ b/src/core/hachimi.rs
@@ -91,6 +91,8 @@ pub struct Hachimi {
 
 static INSTANCE: OnceCell<Arc<Hachimi>> = OnceCell::new();
 
+static SKILL_DATA_DESC_REBUILD_REQUESTED: AtomicBool = AtomicBool::new(false);
+
 impl Hachimi {
     pub fn init() -> bool {
         if INSTANCE.get().is_some() {
@@ -284,10 +286,20 @@ impl Hachimi {
         self.localized_data.store(Arc::new(new_data));
 
         if !self.skill_data_desc.load().descs.is_empty() {
-            let data = SkillDataDesc::load_from_db();
-            if !data.descs.is_empty() {
-                self.skill_data_desc.store(Arc::new(data));
-            }
+            SKILL_DATA_DESC_REBUILD_REQUESTED.store(true, atomic::Ordering::Release);
+        }
+    }
+
+    pub fn drain_skill_data_desc_rebuild(&self) {
+        if !SKILL_DATA_DESC_REBUILD_REQUESTED.swap(false, atomic::Ordering::AcqRel) {
+            return;
+        }
+        if self.skill_data_desc.load().descs.is_empty() {
+            return;
+        }
+        let data = SkillDataDesc::load_from_db();
+        if !data.descs.is_empty() {
+            self.skill_data_desc.store(Arc::new(data));
         }
     }
 

--- a/src/il2cpp/hook/umamusume/GallopUtil.rs
+++ b/src/il2cpp/hook/umamusume/GallopUtil.rs
@@ -21,13 +21,15 @@ type LineHeadWrapCommonFn = extern "C" fn(
 extern "C" fn LineHeadWrapCommon(
     s: *mut Il2CppString, line_char_count: i32, handling_type: i32, is_match_delegate: *mut Il2CppDelegate
 ) -> *mut Il2CppString {
-    // Don't wrap text if prewrapped or requested.
-    if NO_WRAP.load(Ordering::Relaxed) || utils::game_str_has_newline(s) {
+    if NO_WRAP.load(Ordering::Relaxed) {
         return s;
     }
 
     if let Some(wrapped) = utils::wrap_text_il2cpp(s, line_char_count) {
         return wrapped;
+    }
+    if utils::game_str_has_newline(s) {
+        return s;
     }
     get_orig_fn!(LineHeadWrapCommon, LineHeadWrapCommonFn)(s, line_char_count, handling_type, is_match_delegate)
 }

--- a/src/il2cpp/hook/umamusume/GameSystem.rs
+++ b/src/il2cpp/hook/umamusume/GameSystem.rs
@@ -34,6 +34,7 @@ fn apply_free_camera_live_pause_request() {
 
 extern "C" fn GameSystem_Update(this: *mut Il2CppObject) {
     crate::core::gui::race_slider_drain();
+    Hachimi::instance().drain_skill_data_desc_rebuild();
 
     #[cfg(target_os = "windows")]
     {


### PR DESCRIPTION
- Defer SkillDataDesc cache rebuild to the il2cpp thread to avoid thread violation crashes
- Fix Chinese texts not wrapping properly

<!--
Don't submit a Pull Request with copy-pasted, untested code generated by ChatGPT, Copilot, or other AI tools.

There has been a couple of PRs lately dumped on the project that don't work properly, mess up the formatting, or have to be completely rewritten. As a project maintainer, I don't have the time to fix code you didn't write or test yourself.

AI code has no clear copyright protection under US law and often copies code from other projects without credit, which causes licensing problems for this repo.

Using AI tools to help debug, look up syntax, or assist with formatting is fine, provided that:
- **You understand the code:** You must be able to explain how your changes work and address feedback during review.
- **You tested it locally:** The code builds, runs, adheres to the project's style, and doesn't introduce regressions.
- **No uncredited code:** The output does not pull copyrighted code from other projects without proper licensing and attribution.

If a PR violates any of these policies, it will be ghosted.
-->